### PR TITLE
Implement message sending flow

### DIFF
--- a/model/src/main/proto/spine_examples/chatspn/chat/chat_members.proto
+++ b/model/src/main/proto/spine_examples/chatspn/chat/chat_members.proto
@@ -39,11 +39,11 @@ import "spine_examples/chatspn/identifiers.proto";
 
 // Members in the chat.
 message ChatMembers {
-  option (entity) = { kind: PROJECTION };
+    option (entity) = { kind: PROJECTION };
 
-  // The ID of the chat.
-  ChatId id = 1;
+    // The ID of the chat.
+    ChatId id = 1;
 
-  // List of the chat members.
-  repeated spine.core.UserId member = 2 [(required) = true, (distinct) = true];
+    // List of the chat members.
+    repeated spine.core.UserId member = 2 [(required) = true, (distinct) = true];
 }

--- a/model/src/main/proto/spine_examples/chatspn/chat/chat_members.proto
+++ b/model/src/main/proto/spine_examples/chatspn/chat/chat_members.proto
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2023, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+syntax = "proto3";
+
+package spine_examples.chatspn.chat;
+
+import "spine/options.proto";
+
+option (type_url_prefix) = "type.chatspn.spine.io";
+option java_package = "io.spine.examples.chatspn.chat";
+option java_outer_classname = "ChatMembersProto";
+option java_multiple_files = true;
+
+import "spine/core/user_id.proto";
+import "spine_examples/chatspn/identifiers.proto";
+
+// Members in the chat.
+message ChatMembers {
+  option (entity) = { kind: PROJECTION };
+
+  // The ID of the chat.
+  ChatId id = 1;
+
+  // List of the chat members.
+  repeated spine.core.UserId member = 2 [(required) = true, (distinct) = true];
+}

--- a/model/src/main/proto/spine_examples/chatspn/message/message.proto
+++ b/model/src/main/proto/spine_examples/chatspn/message/message.proto
@@ -57,3 +57,11 @@ message Message {
     // Time when this message was posted.
     google.protobuf.Timestamp when_posted = 5 [(required) = true];
 }
+
+// The process of message sending to the chat.
+message MessageSending {
+    option (entity) = { kind: PROCESS_MANAGER };
+
+    // The ID of the message to send.
+    MessageId id = 1;
+}

--- a/model/src/main/proto/spine_examples/chatspn/message/sending_commands.proto
+++ b/model/src/main/proto/spine_examples/chatspn/message/sending_commands.proto
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2023, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+syntax = "proto3";
+
+package spine_examples.chatspn.message;
+
+import "spine/options.proto";
+
+option (type_url_prefix) = "type.chatspn.spine.io";
+option java_package = "io.spine.examples.chatspn.message.sendingcommand";
+option java_outer_classname = "CommandsProto";
+option java_multiple_files = true;
+
+import "spine/core/user_id.proto";
+import "spine_examples/chatspn/identifiers.proto";
+
+// Tells to send a new message to the chat.
+message SendMessage {
+
+    // The ID of the message to send.
+    MessageId id = 1;
+
+    // The ID of the chat to send this message in.
+    ChatId chat = 2 [(required) = true];
+
+    // The ID of the user who tells to send this message.
+    spine.core.UserId user = 3 [(required) = true];
+
+    // The message text content.
+    string content = 4 [(required) = true];
+}

--- a/model/src/main/proto/spine_examples/chatspn/message/sending_events.proto
+++ b/model/src/main/proto/spine_examples/chatspn/message/sending_events.proto
@@ -36,7 +36,6 @@ option java_multiple_files = true;
 
 import "spine/core/user_id.proto";
 import "spine_examples/chatspn/identifiers.proto";
-import "google/protobuf/timestamp.proto";
 
 // A message has been sent.
 message MessageSent {

--- a/model/src/main/proto/spine_examples/chatspn/message/sending_events.proto
+++ b/model/src/main/proto/spine_examples/chatspn/message/sending_events.proto
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2023, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+syntax = "proto3";
+
+package spine_examples.chatspn.message;
+
+import "spine/options.proto";
+
+option (type_url_prefix) = "type.chatspn.spine.io";
+option java_package = "io.spine.examples.chatspn.message.sendingevent";
+option java_outer_classname = "EventsProto";
+option java_multiple_files = true;
+
+import "spine/core/user_id.proto";
+import "spine_examples/chatspn/identifiers.proto";
+import "google/protobuf/timestamp.proto";
+
+// A message has been sent.
+message MessageSent {
+
+    // The ID of the sent message.
+    MessageId id = 1;
+
+    // The ID of the chat in which the message was sent.
+    ChatId chat = 2 [(required) = true];
+
+    // The ID of the user who sent the message.
+    spine.core.UserId user = 3 [(required) = true];
+
+    // The sent message text content.
+    string content = 4 [(required) = true];
+}

--- a/model/src/main/proto/spine_examples/chatspn/message/sending_rejections.proto
+++ b/model/src/main/proto/spine_examples/chatspn/message/sending_rejections.proto
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2023, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+syntax = "proto3";
+
+package spine_examples.chatspn.message;
+
+import "spine/options.proto";
+
+option (type_url_prefix) = "type.chatspn.spine.io";
+option java_package = "io.spine.examples.chatspn.message.sendingrejection";
+option java_multiple_files = false;
+
+import "spine/core/user_id.proto";
+import "spine_examples/chatspn/identifiers.proto";
+
+// A message cannot be sent to the chat.
+message MessageCannotBeSent {
+
+    // The ID of the message failed to be sent.
+    MessageId id = 1 [(required) = true];
+
+    // The ID of the chat where the message sending failed
+    ChatId chat = 2 [(required) = true];
+
+    // The ID of the user who failed to send this message.
+    spine.core.UserId user = 3 [(required) = true];
+
+    // The message text content.
+    string content = 4 [(required) = true];
+}

--- a/server/src/main/java/io/spine/examples/chatspn/server/ChatsContext.java
+++ b/server/src/main/java/io/spine/examples/chatspn/server/ChatsContext.java
@@ -29,6 +29,7 @@ package io.spine.examples.chatspn.server;
 import io.spine.examples.chatspn.server.chat.ChatAggregate;
 import io.spine.examples.chatspn.server.chat.ChatMembersRepository;
 import io.spine.examples.chatspn.server.message.MessageAggregate;
+import io.spine.examples.chatspn.server.message.MessageSendingRepository;
 import io.spine.examples.chatspn.server.user.UserAggregate;
 import io.spine.examples.chatspn.server.user.UserProfileRepository;
 import io.spine.server.BoundedContext;
@@ -59,6 +60,7 @@ public final class ChatsContext {
                 .add(DefaultRepository.of(ChatAggregate.class))
                 .add(DefaultRepository.of(MessageAggregate.class))
                 .add(new UserProfileRepository())
-                .add(new ChatMembersRepository());
+                .add(new ChatMembersRepository())
+                .add(new MessageSendingRepository());
     }
 }

--- a/server/src/main/java/io/spine/examples/chatspn/server/ProjectionProvider.java
+++ b/server/src/main/java/io/spine/examples/chatspn/server/ProjectionProvider.java
@@ -50,7 +50,6 @@ import static io.spine.protobuf.AnyPacker.unpack;
  *         {@code Projection} state type.
  */
 public final class ProjectionProvider<I, S extends EntityState> {
-
     private final Stand stand;
     private final Class<S> projectionStateClass;
 

--- a/server/src/main/java/io/spine/examples/chatspn/server/ProjectionProvider.java
+++ b/server/src/main/java/io/spine/examples/chatspn/server/ProjectionProvider.java
@@ -62,13 +62,13 @@ public final class ProjectionProvider<I, S extends EntityState> {
     /**
      * Querying projections by identifiers.
      */
-    public List<S> getProjections(List<I> ids, CommandContext ctx) {
+    public List<S> getProjections(ImmutableSet<I> ids, CommandContext ctx) {
         QueryFactory queryFactory = ActorRequestFactory
                 .fromContext(ctx.getActorContext())
                 .query();
         Query query = queryFactory.byIds(
                 projectionStateClass,
-                ImmutableSet.of(ids)
+                ids
         );
         return executeAndUnpackResponse(query);
     }

--- a/server/src/main/java/io/spine/examples/chatspn/server/ProjectionProvider.java
+++ b/server/src/main/java/io/spine/examples/chatspn/server/ProjectionProvider.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2023, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.examples.chatspn.server;
+
+import com.google.common.collect.ImmutableSet;
+import io.spine.base.EntityState;
+import io.spine.client.ActorRequestFactory;
+import io.spine.client.Query;
+import io.spine.client.QueryFactory;
+import io.spine.client.QueryResponse;
+import io.spine.core.CommandContext;
+import io.spine.grpc.MemoizingObserver;
+import io.spine.server.stand.Stand;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static io.spine.protobuf.AnyPacker.unpack;
+
+/**
+ * {@link Stand} wrapper to simplify the projections querying.
+ *
+ * @param <I>
+ *         {@code Projection} id type.
+ * @param <S>
+ *         {@code Projection} state type.
+ */
+public final class ProjectionProvider<I, S extends EntityState> {
+
+    private final Stand stand;
+    private final Class<S> projectionStateClass;
+
+    public ProjectionProvider(Stand stand, Class<S> projectionStateClass) {
+        this.stand = stand;
+        this.projectionStateClass = projectionStateClass;
+    }
+
+    /**
+     * Querying projections by identifiers.
+     */
+    public List<S> getProjections(List<I> ids, CommandContext ctx) {
+        QueryFactory queryFactory = ActorRequestFactory
+                .fromContext(ctx.getActorContext())
+                .query();
+        Query query = queryFactory.byIds(
+                projectionStateClass,
+                ImmutableSet.of(ids)
+        );
+        return executeAndUnpackResponse(query);
+    }
+
+    private List<S> executeAndUnpackResponse(Query query) {
+        MemoizingObserver<QueryResponse> observer = new MemoizingObserver<>();
+        stand.execute(query, observer);
+        QueryResponse response = observer.firstResponse();
+        return response.getMessageList()
+                       .stream()
+                       .map(state -> unpack(state.getState(), projectionStateClass))
+                       .collect(Collectors.toList());
+    }
+}

--- a/server/src/main/java/io/spine/examples/chatspn/server/chat/ChatMembersProjection.java
+++ b/server/src/main/java/io/spine/examples/chatspn/server/chat/ChatMembersProjection.java
@@ -41,6 +41,7 @@ public final class ChatMembersProjection
     @Subscribe
     void on(ChatCreated e) {
         builder().setId(e.getId())
-                 .addAllMember(e.getMemberList());
+                 .addAllMember(e.getMemberList())
+                 .addMember(e.getCreator());
     }
 }

--- a/server/src/main/java/io/spine/examples/chatspn/server/chat/ChatMembersProjection.java
+++ b/server/src/main/java/io/spine/examples/chatspn/server/chat/ChatMembersProjection.java
@@ -24,41 +24,23 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package io.spine.examples.chatspn.server;
+package io.spine.examples.chatspn.server.chat;
 
-import io.spine.examples.chatspn.server.chat.ChatAggregate;
-import io.spine.examples.chatspn.server.chat.ChatMembersRepository;
-import io.spine.examples.chatspn.server.message.MessageAggregate;
-import io.spine.examples.chatspn.server.user.UserAggregate;
-import io.spine.examples.chatspn.server.user.UserProfileRepository;
-import io.spine.server.BoundedContext;
-import io.spine.server.BoundedContextBuilder;
-import io.spine.server.DefaultRepository;
+import io.spine.core.Subscribe;
+import io.spine.examples.chatspn.ChatId;
+import io.spine.examples.chatspn.chat.ChatMembers;
+import io.spine.examples.chatspn.chat.event.ChatCreated;
+import io.spine.server.projection.Projection;
 
 /**
- * Configures Chats Bounded Context with repositories.
+ * Manages instances of {@code ChatMembers} projections.
  */
-public final class ChatsContext {
+public final class ChatMembersProjection
+        extends Projection<ChatId, ChatMembers, ChatMembers.Builder> {
 
-    static final String NAME = "Chats";
-
-    /**
-     * Prevents instantiation of this class.
-     */
-    private ChatsContext() {
-    }
-
-    /**
-     * Creates {@code BoundedContextBuilder} for the Chats context
-     * and fills it with repositories.
-     */
-    public static BoundedContextBuilder newBuilder() {
-        return BoundedContext
-                .singleTenant(NAME)
-                .add(DefaultRepository.of(UserAggregate.class))
-                .add(DefaultRepository.of(ChatAggregate.class))
-                .add(DefaultRepository.of(MessageAggregate.class))
-                .add(new UserProfileRepository())
-                .add(new ChatMembersRepository());
+    @Subscribe
+    void on(ChatCreated e) {
+        builder().setId(e.getId())
+                 .addAllMember(e.getMemberList());
     }
 }

--- a/server/src/main/java/io/spine/examples/chatspn/server/chat/ChatMembersRepository.java
+++ b/server/src/main/java/io/spine/examples/chatspn/server/chat/ChatMembersRepository.java
@@ -24,41 +24,27 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package io.spine.examples.chatspn.server;
+package io.spine.examples.chatspn.server.chat;
 
-import io.spine.examples.chatspn.server.chat.ChatAggregate;
-import io.spine.examples.chatspn.server.chat.ChatMembersRepository;
-import io.spine.examples.chatspn.server.message.MessageAggregate;
-import io.spine.examples.chatspn.server.user.UserAggregate;
-import io.spine.examples.chatspn.server.user.UserProfileRepository;
-import io.spine.server.BoundedContext;
-import io.spine.server.BoundedContextBuilder;
-import io.spine.server.DefaultRepository;
+import com.google.errorprone.annotations.OverridingMethodsMustInvokeSuper;
+import io.spine.examples.chatspn.ChatId;
+import io.spine.examples.chatspn.chat.ChatMembers;
+import io.spine.examples.chatspn.chat.event.ChatCreated;
+import io.spine.server.projection.ProjectionRepository;
+import io.spine.server.route.EventRouting;
+
+import static io.spine.server.route.EventRoute.withId;
 
 /**
- * Configures Chats Bounded Context with repositories.
+ * The repository for managing {@link ChatMembersProjection} instances.
  */
-public final class ChatsContext {
+public final class ChatMembersRepository
+        extends ProjectionRepository<ChatId, ChatMembersProjection, ChatMembers> {
 
-    static final String NAME = "Chats";
-
-    /**
-     * Prevents instantiation of this class.
-     */
-    private ChatsContext() {
-    }
-
-    /**
-     * Creates {@code BoundedContextBuilder} for the Chats context
-     * and fills it with repositories.
-     */
-    public static BoundedContextBuilder newBuilder() {
-        return BoundedContext
-                .singleTenant(NAME)
-                .add(DefaultRepository.of(UserAggregate.class))
-                .add(DefaultRepository.of(ChatAggregate.class))
-                .add(DefaultRepository.of(MessageAggregate.class))
-                .add(new UserProfileRepository())
-                .add(new ChatMembersRepository());
+    @OverridingMethodsMustInvokeSuper
+    @Override
+    protected void setupEventRouting(EventRouting<ChatId> routing) {
+        super.setupEventRouting(routing);
+        routing.route(ChatCreated.class, (event, context) -> withId(event.getId()));
     }
 }

--- a/server/src/main/java/io/spine/examples/chatspn/server/message/MessageSendingProcess.java
+++ b/server/src/main/java/io/spine/examples/chatspn/server/message/MessageSendingProcess.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2023, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.examples.chatspn.server.message;
+
+import io.spine.examples.chatspn.MessageId;
+import io.spine.examples.chatspn.message.MessageSending;
+import io.spine.examples.chatspn.message.command.PostMessage;
+import io.spine.examples.chatspn.message.event.MessagePosted;
+import io.spine.examples.chatspn.message.sendingcommand.SendMessage;
+import io.spine.examples.chatspn.message.sendingevent.MessageSent;
+import io.spine.server.command.Command;
+import io.spine.server.event.React;
+import io.spine.server.procman.ProcessManager;
+
+/**
+ * Coordinates the message sending to the chat.
+ */
+public class MessageSendingProcess
+        extends ProcessManager<MessageId, MessageSending, MessageSending.Builder> {
+
+    /**
+     * Issues a command to post message to the chat.
+     */
+    @Command
+    PostMessage on(SendMessage c) {
+        initState(c);
+        return PostMessage
+                .newBuilder()
+                .setId(c.getId())
+                .setChat(c.getChat())
+                .setUser(c.getUser())
+                .setContent(c.getContent())
+                .vBuild();
+    }
+
+    private void initState(SendMessage c) {
+        builder().setId(c.getId());
+    }
+
+    /**
+     * Archives the process when the message was sent.
+     */
+    @React
+    MessageSent on(MessagePosted e) {
+        setArchived(true);
+        return MessageSent
+                .newBuilder()
+                .setId(e.getId())
+                .setChat(e.getChat())
+                .setUser(e.getUser())
+                .setContent(e.getContent())
+                .vBuild();
+    }
+}

--- a/server/src/main/java/io/spine/examples/chatspn/server/message/MessageSendingProcess.java
+++ b/server/src/main/java/io/spine/examples/chatspn/server/message/MessageSendingProcess.java
@@ -35,12 +35,21 @@ import io.spine.examples.chatspn.message.sendingevent.MessageSent;
 import io.spine.server.command.Command;
 import io.spine.server.event.React;
 import io.spine.server.procman.ProcessManager;
+import io.spine.server.stand.Stand;
+import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
 
 /**
  * Coordinates the message sending to the chat.
  */
-public class MessageSendingProcess
+public final class MessageSendingProcess
         extends ProcessManager<MessageId, MessageSending, MessageSending.Builder> {
+
+    /**
+     * {@link Stand} of the bounded context, in which this process manager
+     * is registered as an entity.
+     */
+    @MonotonicNonNull
+    private Stand stand;
 
     /**
      * Issues a command to post message to the chat.
@@ -74,5 +83,9 @@ public class MessageSendingProcess
                 .setUser(e.getUser())
                 .setContent(e.getContent())
                 .vBuild();
+    }
+
+    void inject(Stand stand) {
+        this.stand = stand;
     }
 }

--- a/server/src/main/java/io/spine/examples/chatspn/server/message/MessageSendingProcess.java
+++ b/server/src/main/java/io/spine/examples/chatspn/server/message/MessageSendingProcess.java
@@ -27,12 +27,8 @@
 package io.spine.examples.chatspn.server.message;
 
 import com.google.common.collect.ImmutableSet;
-import com.google.protobuf.Any;
-import io.spine.client.ActorRequestFactory;
-import io.spine.client.Query;
-import io.spine.client.QueryFactory;
-import io.spine.client.QueryResponse;
 import io.spine.core.CommandContext;
+import io.spine.examples.chatspn.ChatId;
 import io.spine.examples.chatspn.MessageId;
 import io.spine.examples.chatspn.chat.ChatMembers;
 import io.spine.examples.chatspn.message.MessageSending;
@@ -41,14 +37,12 @@ import io.spine.examples.chatspn.message.event.MessagePosted;
 import io.spine.examples.chatspn.message.sendingcommand.SendMessage;
 import io.spine.examples.chatspn.message.sendingevent.MessageSent;
 import io.spine.examples.chatspn.message.sendingrejection.MessageCannotBeSent;
-import io.spine.grpc.MemoizingObserver;
+import io.spine.examples.chatspn.server.ProjectionProvider;
 import io.spine.server.command.Command;
 import io.spine.server.event.React;
 import io.spine.server.procman.ProcessManager;
 import io.spine.server.stand.Stand;
 import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
-
-import static io.spine.protobuf.AnyPacker.unpack;
 
 /**
  * Coordinates the message sending to the chat.
@@ -61,7 +55,7 @@ public final class MessageSendingProcess
      * is registered as an entity.
      */
     @MonotonicNonNull
-    private Stand stand;
+    private ProjectionProvider<ChatId, ChatMembers> projectionProvider;
 
     /**
      * Issues a command to post message to the chat.
@@ -72,13 +66,9 @@ public final class MessageSendingProcess
     @Command
     PostMessage on(SendMessage c, CommandContext ctx) throws MessageCannotBeSent {
         initState(c);
-
-        QueryFactory queryFactory = queryFactoryOnTopOf(ctx);
-        Query query = queryFactory.byIds(
-                ChatMembers.class,
-                ImmutableSet.of(c.getChat())
-        );
-        ChatMembers chatMembers = executeAndUnpackResponse(query);
+        ChatMembers chatMembers = projectionProvider
+                .getProjections(ImmutableSet.of(c.getChat()), ctx)
+                .get(0);
 
         if (chatMembers.getMemberList()
                        .contains(c.getUser())) {
@@ -119,23 +109,7 @@ public final class MessageSendingProcess
                 .vBuild();
     }
 
-    private QueryFactory queryFactoryOnTopOf(CommandContext ctx) {
-        ActorRequestFactory requestFactory =
-                ActorRequestFactory.fromContext(ctx.getActorContext());
-        return requestFactory.query();
-    }
-
-    private ChatMembers executeAndUnpackResponse(Query query) {
-        MemoizingObserver<QueryResponse> observer = new MemoizingObserver<>();
-        stand.execute(query, observer);
-        QueryResponse response = observer.firstResponse();
-        Any packed = response.getMessageList()
-                             .get(0)
-                             .getState();
-        return unpack(packed, ChatMembers.class);
-    }
-
-    void inject(Stand stand) {
-        this.stand = stand;
+    void inject(ProjectionProvider<ChatId, ChatMembers> provider) {
+        projectionProvider = provider;
     }
 }

--- a/server/src/main/java/io/spine/examples/chatspn/server/message/MessageSendingProcess.java
+++ b/server/src/main/java/io/spine/examples/chatspn/server/message/MessageSendingProcess.java
@@ -51,8 +51,8 @@ public final class MessageSendingProcess
         extends ProcessManager<MessageId, MessageSending, MessageSending.Builder> {
 
     /**
-     * {@link Stand} of the bounded context, in which this process manager
-     * is registered as an entity.
+     * {@link ProjectionProvider} with {@link Stand} of the bounded context,
+     * in which this process manager is registered as an entity.
      */
     @MonotonicNonNull
     private ProjectionProvider<ChatId, ChatMembers> projectionProvider;

--- a/server/src/main/java/io/spine/examples/chatspn/server/message/MessageSendingRepository.java
+++ b/server/src/main/java/io/spine/examples/chatspn/server/message/MessageSendingRepository.java
@@ -28,8 +28,10 @@ package io.spine.examples.chatspn.server.message;
 
 import com.google.errorprone.annotations.OverridingMethodsMustInvokeSuper;
 import io.spine.examples.chatspn.MessageId;
+import io.spine.examples.chatspn.chat.ChatMembers;
 import io.spine.examples.chatspn.message.MessageSending;
 import io.spine.examples.chatspn.message.event.MessagePosted;
+import io.spine.examples.chatspn.server.ProjectionProvider;
 import io.spine.server.procman.ProcessManagerRepository;
 import io.spine.server.route.EventRouting;
 
@@ -52,6 +54,6 @@ public final class MessageSendingRepository
     @Override
     protected void configure(MessageSendingProcess p) {
         super.configure(p);
-        p.inject(context().stand());
+        p.inject(new ProjectionProvider<>(context().stand(), ChatMembers.class));
     }
 }

--- a/server/src/main/java/io/spine/examples/chatspn/server/message/MessageSendingRepository.java
+++ b/server/src/main/java/io/spine/examples/chatspn/server/message/MessageSendingRepository.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2023, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.examples.chatspn.server.message;
+
+import com.google.errorprone.annotations.OverridingMethodsMustInvokeSuper;
+import io.spine.examples.chatspn.MessageId;
+import io.spine.examples.chatspn.message.MessageSending;
+import io.spine.examples.chatspn.message.event.MessagePosted;
+import io.spine.server.procman.ProcessManagerRepository;
+import io.spine.server.route.EventRouting;
+
+import static io.spine.server.route.EventRoute.withId;
+
+/**
+ * Manages instances of {@link MessageSendingProcess}.
+ */
+public final class MessageSendingRepository
+        extends ProcessManagerRepository<MessageId, MessageSendingProcess, MessageSending> {
+
+    @OverridingMethodsMustInvokeSuper
+    @Override
+    protected void setupEventRouting(EventRouting<MessageId> routing) {
+        super.setupEventRouting(routing);
+        routing.route(MessagePosted.class, (event, context) -> withId(event.getId()));
+    }
+
+    @OverridingMethodsMustInvokeSuper
+    @Override
+    protected void configure(MessageSendingProcess p) {
+        super.configure(p);
+        p.inject(context().stand());
+    }
+}

--- a/server/src/test/java/io/spine/examples/chatspn/server/chat/ChatMembersProjectionTest.java
+++ b/server/src/test/java/io/spine/examples/chatspn/server/chat/ChatMembersProjectionTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2023, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.examples.chatspn.server.chat;
+
+import io.spine.examples.chatspn.ChatId;
+import io.spine.examples.chatspn.chat.ChatMembers;
+import io.spine.examples.chatspn.chat.command.CreateChat;
+import io.spine.examples.chatspn.server.ChatsContext;
+import io.spine.server.BoundedContextBuilder;
+import io.spine.testing.core.given.GivenUserId;
+import io.spine.testing.server.blackbox.ContextAwareTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static io.spine.testing.TestValues.randomString;
+
+@DisplayName("`ChatMembersProjection` should")
+class ChatMembersProjectionTest extends ContextAwareTest {
+
+    @Override
+    protected BoundedContextBuilder contextBuilder() {
+        return ChatsContext.newBuilder();
+    }
+
+    @Test
+    @DisplayName("display `ChatMembers`, as soon as `Chat` created")
+    void reactOnChatCreation() {
+        CreateChat command = CreateChat
+                .newBuilder()
+                .setId(ChatId.generate())
+                .setName(randomString())
+                .setCreator(GivenUserId.generated())
+                .addMember(GivenUserId.generated())
+                .vBuild();
+        context().receivesCommand(command);
+
+        ChatMembers expected = ChatMembers
+                .newBuilder()
+                .setId(command.getId())
+                .addAllMember(command.getMemberList())
+                .addMember(command.getCreator())
+                .vBuild();
+
+        context().assertState(command.getId(), expected);
+    }
+}

--- a/server/src/test/java/io/spine/examples/chatspn/server/given/MessageSendingTestEnv.java
+++ b/server/src/test/java/io/spine/examples/chatspn/server/given/MessageSendingTestEnv.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2023, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.examples.chatspn.server.given;
+
+import io.spine.core.UserId;
+import io.spine.examples.chatspn.ChatId;
+import io.spine.examples.chatspn.MessageId;
+import io.spine.examples.chatspn.chat.Chat;
+import io.spine.examples.chatspn.chat.command.CreateChat;
+import io.spine.examples.chatspn.message.Message;
+import io.spine.examples.chatspn.message.sendingcommand.SendMessage;
+import io.spine.testing.core.given.GivenUserId;
+import io.spine.testing.server.blackbox.BlackBoxContext;
+
+import static io.spine.testing.TestValues.randomString;
+
+public class MessageSendingTestEnv {
+
+    /**
+     * Prevents instantiation of this class.
+     */
+    private MessageSendingTestEnv() {
+
+    }
+
+    public static Chat createRandomChat(BlackBoxContext context) {
+        Chat chat = Chat
+                .newBuilder()
+                .setId(ChatId.generate())
+                .addMember(GivenUserId.generated())
+                .addMember(GivenUserId.generated())
+                .setName(randomString())
+                .vBuild();
+        CreateChat command = CreateChat
+                .newBuilder()
+                .setId(chat.getId())
+                .setCreator(chat.getMember(0))
+                .addMember(chat.getMember(1))
+                .setName(chat.getName())
+                .vBuild();
+        context.receivesCommand(command);
+        return chat;
+    }
+
+    public static Message sendMessage(ChatId chat, UserId user, BlackBoxContext context) {
+        Message message = Message
+                .newBuilder()
+                .setId(MessageId.generate())
+                .setChat(chat)
+                .setUser(user)
+                .setContent(randomString())
+                .buildPartial();
+        SendMessage command = SendMessage
+                .newBuilder()
+                .setId(message.getId())
+                .setChat(chat)
+                .setUser(user)
+                .setContent(message.getContent())
+                .vBuild();
+        context.receivesCommand(command);
+        return message;
+    }
+}

--- a/server/src/test/java/io/spine/examples/chatspn/server/message/MessageSendingTest.java
+++ b/server/src/test/java/io/spine/examples/chatspn/server/message/MessageSendingTest.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2023, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.examples.chatspn.server.message;
+
+import io.spine.examples.chatspn.chat.Chat;
+import io.spine.examples.chatspn.message.Message;
+import io.spine.examples.chatspn.message.sendingevent.MessageSent;
+import io.spine.examples.chatspn.message.sendingrejection.SendingRejections.MessageCannotBeSent;
+import io.spine.examples.chatspn.server.ChatsContext;
+import io.spine.server.BoundedContextBuilder;
+import io.spine.testing.core.given.GivenUserId;
+import io.spine.testing.server.blackbox.ContextAwareTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static io.spine.examples.chatspn.server.given.MessageSendingTestEnv.createRandomChat;
+import static io.spine.examples.chatspn.server.given.MessageSendingTestEnv.sendMessage;
+
+@DisplayName("`MessageSending` should")
+public final class MessageSendingTest extends ContextAwareTest {
+
+    @Override
+    protected BoundedContextBuilder contextBuilder() {
+        return ChatsContext.newBuilder();
+    }
+
+    @Test
+    @DisplayName("emit `MessageSent` event")
+    void event() {
+        Chat chat = createRandomChat(context());
+        Message message = sendMessage(chat.getId(),
+                                      chat.getMember(0),
+                                      context());
+
+        MessageSent expectedEvent = MessageSent
+                .newBuilder()
+                .setId(message.getId())
+                .setChat(message.getChat())
+                .setUser(message.getUser())
+                .setContent(message.getContent())
+                .vBuild();
+
+        context().assertEvents()
+                 .withType(MessageSent.class)
+                 .hasSize(1);
+        context().assertEvents()
+                 .withType(MessageSent.class)
+                 .message(0)
+                 .isEqualTo(expectedEvent);
+    }
+
+    @Test
+    @DisplayName("post message")
+    void state() {
+        Chat chat = createRandomChat(context());
+        Message message = sendMessage(chat.getId(),
+                                      chat.getMember(0),
+                                      context());
+        context().assertState(message.getId(), Message.class)
+                 .comparingExpectedFieldsOnly()
+                 .isEqualTo(message);
+    }
+
+    @Test
+    @DisplayName("reject when the message sender is not the chat member")
+    void rejection() {
+        Chat chat = createRandomChat(context());
+        Message message = sendMessage(chat.getId(),
+                                      GivenUserId.generated(),
+                                      context());
+
+        MessageCannotBeSent expectedRejection = MessageCannotBeSent
+                .newBuilder()
+                .setId(message.getId())
+                .setChat(message.getChat())
+                .setUser(message.getUser())
+                .setContent(message.getContent())
+                .vBuild();
+
+        context().assertEvents()
+                 .withType(MessageCannotBeSent.class)
+                 .message(0)
+                 .isEqualTo(expectedRejection);
+    }
+
+    @Test
+    @DisplayName("archive itself after work")
+    void archiving() {
+        Chat chat = createRandomChat(context());
+        Message message = sendMessage(chat.getId(),
+                                      chat.getMember(0),
+                                      context());
+        context().assertEntity(message.getId(), MessageSendingProcess.class)
+                 .archivedFlag()
+                 .isTrue();
+    }
+}


### PR DESCRIPTION
This PR adds an implementation of the message sending flow.

Message sending flow model:
![image](https://user-images.githubusercontent.com/106074440/226051798-d0016b3c-d706-4d73-8cf9-54518751cb9d.png)

According to the main flow, the `ChatMembers` projection and the `ProjectionProvider` were implemented.
`ProjectionProvider` is a `Stand` wrapper to simplify requests for the projection state.