### PR TITLE
Implement message removal flow

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -1,11 +1,5 @@
 <component name="ProjectCodeStyleConfiguration">
   <code_scheme name="Project" version="173">
-    <option name="OTHER_INDENT_OPTIONS">
-      <value>
-        <option name="INDENT_SIZE" value="8" />
-        <option name="TAB_SIZE" value="8" />
-      </value>
-    </option>
     <option name="RIGHT_MARGIN" value="100" />
     <DartCodeStyleSettings>
       <option name="DELEGATE_TO_DARTFMT" value="false" />

--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -1,5 +1,11 @@
 <component name="ProjectCodeStyleConfiguration">
   <code_scheme name="Project" version="173">
+    <option name="OTHER_INDENT_OPTIONS">
+      <value>
+        <option name="INDENT_SIZE" value="8" />
+        <option name="TAB_SIZE" value="8" />
+      </value>
+    </option>
     <option name="RIGHT_MARGIN" value="100" />
     <DartCodeStyleSettings>
       <option name="DELEGATE_TO_DARTFMT" value="false" />

--- a/model/src/main/proto/spine_examples/chatspn/message/message.proto
+++ b/model/src/main/proto/spine_examples/chatspn/message/message.proto
@@ -57,7 +57,7 @@ message Message {
     // Time when this message was posted.
     google.protobuf.Timestamp when_posted = 5 [(required) = true];
 
-    // Answers the question `Is the message removed?`.
+    // Answers the question 'Is the message removed?'.
     bool is_removed = 6 [(required) = true];
 }
 

--- a/model/src/main/proto/spine_examples/chatspn/message/message.proto
+++ b/model/src/main/proto/spine_examples/chatspn/message/message.proto
@@ -56,9 +56,6 @@ message Message {
 
     // Time when this message was posted.
     google.protobuf.Timestamp when_posted = 5 [(required) = true];
-
-    // Answers the question 'Is the message removed?'.
-    bool is_removed = 6 [(required) = true];
 }
 
 // The process of message sending to the chat.

--- a/model/src/main/proto/spine_examples/chatspn/message/removal_commands.proto
+++ b/model/src/main/proto/spine_examples/chatspn/message/removal_commands.proto
@@ -30,57 +30,35 @@ package spine_examples.chatspn.message;
 import "spine/options.proto";
 
 option (type_url_prefix) = "type.chatspn.spine.io";
-option java_package = "io.spine.examples.chatspn.message";
-option java_outer_classname = "MessageProto";
+option java_package = "io.spine.examples.chatspn.message.command";
+option java_outer_classname = "RemovalCommandsProto";
 option java_multiple_files = true;
 
 import "spine/core/user_id.proto";
 import "spine_examples/chatspn/identifiers.proto";
-import "google/protobuf/timestamp.proto";
 
-// A message in the chat.
-message Message {
-    option (entity) = { kind: AGGREGATE };
-
-    // The ID of the message.
-    MessageId id = 1;
-
-    // The ID of the chat in which this message was posted.
-    ChatId chat = 2 [(required) = true];
-
-    // The ID of the user who posted this message.
-    spine.core.UserId user = 3 [(required) = true];
-
-    // The message text content.
-    string content = 4 [(required) = true];
-
-    // Time when this message was posted.
-    google.protobuf.Timestamp when_posted = 5 [(required) = true];
-
-    // Answers the question `Is the message removed?`.
-    bool is_removed = 6 [(required) = true];
-}
-
-// The process of message sending to the chat.
-message MessageSending {
-    option (entity) = { kind: PROCESS_MANAGER };
-
-    // The ID of the message to send.
-    MessageId id = 1;
-}
-
-// The process of message editing.
-message MessageEditing {
-    option (entity) = { kind: PROCESS_MANAGER };
-
-    // The ID of the message to edit.
-    MessageId id = 1;
-}
-
-// The process of message removal.
-message MessageRemoval {
-    option (entity) = { kind: PROCESS_MANAGER };
+// Tells to remove a message in the chat.
+message RemoveMessage {
 
     // The ID of the message to remove.
     MessageId id = 1;
+
+    // The ID of the chat to remove the message in.
+    ChatId chat = 2 [(required) = true];
+
+    // The ID of the user who tells to remove this message.
+    spine.core.UserId user = 3 [(required) = true];
+}
+
+// Tells to mark a message as removed.
+message MarkMessageAsRemoved {
+
+    // The ID of the message to be marked as removed.
+    MessageId id = 1;
+
+    // The ID of the chat to mark the message as removed in.
+    ChatId chat = 2 [(required) = true];
+
+    // The ID of the user who tells to mark message as removed.
+    spine.core.UserId user = 3 [(required) = true];
 }

--- a/model/src/main/proto/spine_examples/chatspn/message/removal_commands.proto
+++ b/model/src/main/proto/spine_examples/chatspn/message/removal_commands.proto
@@ -53,18 +53,18 @@ message RemoveMessage {
     spine.core.UserId user = 3 [(required) = true];
 }
 
-// Tells to mark a message as removed.
+// Tells to mark a message as deleted.
 //
 // The command can be sent by a MessageRemovalProcess.
 //
-message MarkMessageAsRemoved {
+message MarkMessageAsDeleted {
 
-    // The ID of the message to be marked as removed.
+    // The ID of the message to be marked as deleted.
     MessageId id = 1;
 
-    // The ID of the chat to mark the message as removed in.
+    // The ID of the chat to mark the message as deleted in.
     ChatId chat = 2 [(required) = true];
 
-    // The ID of the user who tells to mark message as removed.
+    // The ID of the user who tells to mark message as deleted.
     spine.core.UserId user = 3 [(required) = true];
 }

--- a/model/src/main/proto/spine_examples/chatspn/message/removal_commands.proto
+++ b/model/src/main/proto/spine_examples/chatspn/message/removal_commands.proto
@@ -55,7 +55,7 @@ message RemoveMessage {
 
 // Tells to mark a message as deleted.
 //
-// The command can be sent by a MessageRemovalProcess.
+// The command is typically posted by the corresponding `MessageRemovalProcess`.
 //
 message MarkMessageAsDeleted {
 

--- a/model/src/main/proto/spine_examples/chatspn/message/removal_commands.proto
+++ b/model/src/main/proto/spine_examples/chatspn/message/removal_commands.proto
@@ -38,6 +38,9 @@ import "spine/core/user_id.proto";
 import "spine_examples/chatspn/identifiers.proto";
 
 // Tells to remove a message in the chat.
+//
+// The command can be sent by a chat member who wants to remove a message.
+//
 message RemoveMessage {
 
     // The ID of the message to remove.
@@ -51,6 +54,9 @@ message RemoveMessage {
 }
 
 // Tells to mark a message as removed.
+//
+// The command can be sent by a MessageRemovalProcess.
+//
 message MarkMessageAsRemoved {
 
     // The ID of the message to be marked as removed.

--- a/model/src/main/proto/spine_examples/chatspn/message/removal_events.proto
+++ b/model/src/main/proto/spine_examples/chatspn/message/removal_events.proto
@@ -51,6 +51,10 @@ message MessageRemoved {
 }
 
 // The message failed to be removed.
+//
+// The reason is that the message with the given ID doesn't exist,
+// or has already been marked as removed.
+//
 message MessageRemovalFailed {
 
     // The ID of the message that failed to be removed.

--- a/model/src/main/proto/spine_examples/chatspn/message/removal_events.proto
+++ b/model/src/main/proto/spine_examples/chatspn/message/removal_events.proto
@@ -67,15 +67,15 @@ message MessageRemovalFailed {
     spine.core.UserId user = 3 [(required) = true];
 }
 
-// The message has been marked as removed.
-message MessageMarkedAsRemoved {
+// The message has been marked as deleted.
+message MessageMarkedAsDeleted {
 
-    // The ID of the message that was marked as removed.
+    // The ID of the message that was marked as deleted.
     MessageId id = 1;
 
-    // The ID of the chat in which the message was marked as removed.
+    // The ID of the chat in which the message was marked as deleted.
     ChatId chat = 2 [(required) = true];
 
-    // The ID of the user who marked the message as removed.
+    // The ID of the user who marked the message as deleted.
     spine.core.UserId user = 3 [(required) = true];
 }

--- a/model/src/main/proto/spine_examples/chatspn/message/removal_events.proto
+++ b/model/src/main/proto/spine_examples/chatspn/message/removal_events.proto
@@ -30,57 +30,48 @@ package spine_examples.chatspn.message;
 import "spine/options.proto";
 
 option (type_url_prefix) = "type.chatspn.spine.io";
-option java_package = "io.spine.examples.chatspn.message";
-option java_outer_classname = "MessageProto";
+option java_package = "io.spine.examples.chatspn.message.event";
+option java_outer_classname = "RemovalEventsProto";
 option java_multiple_files = true;
 
 import "spine/core/user_id.proto";
 import "spine_examples/chatspn/identifiers.proto";
-import "google/protobuf/timestamp.proto";
 
-// A message in the chat.
-message Message {
-    option (entity) = { kind: AGGREGATE };
+// A message has been removed.
+message MessageRemoved {
 
-    // The ID of the message.
+    // The ID of the removed message.
     MessageId id = 1;
 
-    // The ID of the chat in which this message was posted.
+    // The ID of the chat in which the message was removed.
     ChatId chat = 2 [(required) = true];
 
-    // The ID of the user who posted this message.
+    // The ID of the user who removed the message.
     spine.core.UserId user = 3 [(required) = true];
-
-    // The message text content.
-    string content = 4 [(required) = true];
-
-    // Time when this message was posted.
-    google.protobuf.Timestamp when_posted = 5 [(required) = true];
-
-    // Answers the question `Is the message removed?`.
-    bool is_removed = 6 [(required) = true];
 }
 
-// The process of message sending to the chat.
-message MessageSending {
-    option (entity) = { kind: PROCESS_MANAGER };
+// The message failed to be removed.
+message MessageRemovalFailed {
 
-    // The ID of the message to send.
+    // The ID of the message that failed to be removed.
     MessageId id = 1;
+
+    // The ID of the chat in which the message failed to be removed.
+    ChatId chat = 2 [(required) = true];
+
+    // The ID of the user who originally asked to remove this message.
+    spine.core.UserId user = 3 [(required) = true];
 }
 
-// The process of message editing.
-message MessageEditing {
-    option (entity) = { kind: PROCESS_MANAGER };
+// The message has been marked as removed.
+message MessageMarkedAsRemoved {
 
-    // The ID of the message to edit.
+    // The ID of the message that was marked as removed.
     MessageId id = 1;
-}
 
-// The process of message removal.
-message MessageRemoval {
-    option (entity) = { kind: PROCESS_MANAGER };
+    // The ID of the chat in which the message was marked as removed.
+    ChatId chat = 2 [(required) = true];
 
-    // The ID of the message to remove.
-    MessageId id = 1;
+    // The ID of the user who marked the message as removed.
+    spine.core.UserId user = 3 [(required) = true];
 }

--- a/model/src/main/proto/spine_examples/chatspn/message/removal_rejections.proto
+++ b/model/src/main/proto/spine_examples/chatspn/message/removal_rejections.proto
@@ -42,10 +42,10 @@ message MessageCannotBeRemoved {
     // The ID of the message that could not be removed.
     MessageId id = 1 [(required) = true];
 
-    // The ID of the chat where the message removal failed.
+    // The ID of the chat where the message could not be removed.
     ChatId chat = 2 [(required) = true];
 
-    // The ID of the user who originally asked to removed this message.
+    // The ID of the user who originally asked to remove this message.
     spine.core.UserId user = 3 [(required) = true];
 }
 

--- a/model/src/main/proto/spine_examples/chatspn/message/removal_rejections.proto
+++ b/model/src/main/proto/spine_examples/chatspn/message/removal_rejections.proto
@@ -52,19 +52,19 @@ message MessageCannotBeRemoved {
     spine.core.UserId user = 3 [(required) = true];
 }
 
-// A message cannot be marked as removed.
+// A message cannot be marked as deleted.
 //
 // The reason is that the message with the given ID doesn't exist,
-// or has already been marked as removed.
+// or has already been marked as deleted.
 //
-message MessageCannotBeMarkedAsRemoved {
+message MessageCannotBeMarkedAsDeleted {
 
-    // The ID of the message that could not be marked as removed.
+    // The ID of the message that could not be marked as deleted.
     MessageId id = 1 [(required) = true];
 
-    // The ID of the chat in which message could not be marked as removed.
+    // The ID of the chat in which message could not be marked as deleted.
     ChatId chat = 2 [(required) = true];
 
-    // The ID of the user who originally asked to mark this message as removed.
+    // The ID of the user who originally asked to mark this message as deleted.
     spine.core.UserId user = 3 [(required) = true];
 }

--- a/model/src/main/proto/spine_examples/chatspn/message/removal_rejections.proto
+++ b/model/src/main/proto/spine_examples/chatspn/message/removal_rejections.proto
@@ -30,57 +30,34 @@ package spine_examples.chatspn.message;
 import "spine/options.proto";
 
 option (type_url_prefix) = "type.chatspn.spine.io";
-option java_package = "io.spine.examples.chatspn.message";
-option java_outer_classname = "MessageProto";
-option java_multiple_files = true;
+option java_package = "io.spine.examples.chatspn.message.rejection";
+option java_multiple_files = false;
 
 import "spine/core/user_id.proto";
 import "spine_examples/chatspn/identifiers.proto";
-import "google/protobuf/timestamp.proto";
 
-// A message in the chat.
-message Message {
-    option (entity) = { kind: AGGREGATE };
+// A message cannot be removed.
+message MessageCannotBeRemoved {
 
-    // The ID of the message.
-    MessageId id = 1;
+    // The ID of the message that could not be removed.
+    MessageId id = 1 [(required) = true];
 
-    // The ID of the chat in which this message was posted.
+    // The ID of the chat where the message removal failed.
     ChatId chat = 2 [(required) = true];
 
-    // The ID of the user who posted this message.
+    // The ID of the user who originally asked to removed this message.
     spine.core.UserId user = 3 [(required) = true];
-
-    // The message text content.
-    string content = 4 [(required) = true];
-
-    // Time when this message was posted.
-    google.protobuf.Timestamp when_posted = 5 [(required) = true];
-
-    // Answers the question `Is the message removed?`.
-    bool is_removed = 6 [(required) = true];
 }
 
-// The process of message sending to the chat.
-message MessageSending {
-    option (entity) = { kind: PROCESS_MANAGER };
+// A message cannot be marked as removed.
+message MessageCannotBeMarkedAsRemoved {
 
-    // The ID of the message to send.
-    MessageId id = 1;
-}
+    // The ID of the message that could not be marked as removed.
+    MessageId id = 1 [(required) = true];
 
-// The process of message editing.
-message MessageEditing {
-    option (entity) = { kind: PROCESS_MANAGER };
+    // The ID of the chat in which message could not be marked as removed.
+    ChatId chat = 2 [(required) = true];
 
-    // The ID of the message to edit.
-    MessageId id = 1;
-}
-
-// The process of message removal.
-message MessageRemoval {
-    option (entity) = { kind: PROCESS_MANAGER };
-
-    // The ID of the message to remove.
-    MessageId id = 1;
+    // The ID of the user who originally asked to mark this message as removed.
+    spine.core.UserId user = 3 [(required) = true];
 }

--- a/model/src/main/proto/spine_examples/chatspn/message/removal_rejections.proto
+++ b/model/src/main/proto/spine_examples/chatspn/message/removal_rejections.proto
@@ -38,7 +38,7 @@ import "spine_examples/chatspn/identifiers.proto";
 
 // A message cannot be removed.
 //
-// The reason is that the user who sent the command to remove the message is not a chat member.
+// Emitted when the user who sent the original command, is not a chat member.
 //
 message MessageCannotBeRemoved {
 
@@ -54,8 +54,8 @@ message MessageCannotBeRemoved {
 
 // A message cannot be marked as deleted.
 //
-// The reason is that the message with the given ID doesn't exist,
-// or has already been marked as deleted.
+// Typically emitted if the message with the specified ID does not exist,
+// or if it has already been marked deleted.
 //
 message MessageCannotBeMarkedAsDeleted {
 

--- a/model/src/main/proto/spine_examples/chatspn/message/removal_rejections.proto
+++ b/model/src/main/proto/spine_examples/chatspn/message/removal_rejections.proto
@@ -37,6 +37,9 @@ import "spine/core/user_id.proto";
 import "spine_examples/chatspn/identifiers.proto";
 
 // A message cannot be removed.
+//
+// The reason is that the user who sent the command to remove the message is not a chat member.
+//
 message MessageCannotBeRemoved {
 
     // The ID of the message that could not be removed.
@@ -50,6 +53,10 @@ message MessageCannotBeRemoved {
 }
 
 // A message cannot be marked as removed.
+//
+// The reason is that the message with the given ID doesn't exist,
+// or has already been marked as removed.
+//
 message MessageCannotBeMarkedAsRemoved {
 
     // The ID of the message that could not be marked as removed.

--- a/server/src/main/java/io/spine/examples/chatspn/server/ChatsContext.java
+++ b/server/src/main/java/io/spine/examples/chatspn/server/ChatsContext.java
@@ -34,6 +34,7 @@ import io.spine.examples.chatspn.server.chat.ChatAggregate;
 import io.spine.examples.chatspn.server.chat.ChatMembersRepository;
 import io.spine.examples.chatspn.server.message.MessageAggregate;
 import io.spine.examples.chatspn.server.message.MessageEditingRepository;
+import io.spine.examples.chatspn.server.message.MessageRemovalRepository;
 import io.spine.examples.chatspn.server.message.MessageSendingRepository;
 import io.spine.server.BoundedContext;
 import io.spine.server.BoundedContextBuilder;
@@ -66,6 +67,7 @@ public final class ChatsContext {
                 .add(new ChatMembersRepository())
                 .add(new MessageSendingRepository())
                 .add(new MessageEditingRepository())
+                .add(new MessageRemovalRepository())
                 .add(DefaultRepository.of(ReservedEmailAggregate.class))
                 .add(new AccountCreationRepository());
     }

--- a/server/src/main/java/io/spine/examples/chatspn/server/message/MessageAggregate.java
+++ b/server/src/main/java/io/spine/examples/chatspn/server/message/MessageAggregate.java
@@ -28,13 +28,13 @@ package io.spine.examples.chatspn.server.message;
 
 import io.spine.examples.chatspn.MessageId;
 import io.spine.examples.chatspn.message.Message;
-import io.spine.examples.chatspn.message.command.MarkMessageAsRemoved;
+import io.spine.examples.chatspn.message.command.MarkMessageAsDeleted;
 import io.spine.examples.chatspn.message.command.PostMessage;
 import io.spine.examples.chatspn.message.command.UpdateMessageContent;
 import io.spine.examples.chatspn.message.event.MessageContentUpdated;
-import io.spine.examples.chatspn.message.event.MessageMarkedAsRemoved;
+import io.spine.examples.chatspn.message.event.MessageMarkedAsDeleted;
 import io.spine.examples.chatspn.message.event.MessagePosted;
-import io.spine.examples.chatspn.message.rejection.MessageCannotBeMarkedAsRemoved;
+import io.spine.examples.chatspn.message.rejection.MessageCannotBeMarkedAsDeleted;
 import io.spine.examples.chatspn.message.rejection.MessageContentCannotBeUpdated;
 import io.spine.server.aggregate.Aggregate;
 import io.spine.server.aggregate.Apply;
@@ -104,22 +104,22 @@ public final class MessageAggregate extends Aggregate<MessageId, Message, Messag
     }
 
     /**
-     * Handles the command to mark a message as removed.
+     * Handles the command to mark a message as deleted.
      *
-     * @throws MessageCannotBeMarkedAsRemoved
-     *         if the message does not exist, or is already marked as removed
+     * @throws MessageCannotBeMarkedAsDeleted
+     *         if the message does not exist, or is already marked as deleted
      */
     @Assign
-    MessageMarkedAsRemoved handle(MarkMessageAsRemoved c) throws MessageCannotBeMarkedAsRemoved {
+    MessageMarkedAsDeleted handle(MarkMessageAsDeleted c) throws MessageCannotBeMarkedAsDeleted {
         if (!state().hasId() || isDeleted()) {
-            throw MessageCannotBeMarkedAsRemoved
+            throw MessageCannotBeMarkedAsDeleted
                     .newBuilder()
                     .setId(c.getId())
                     .setChat(c.getChat())
                     .setUser(c.getUser())
                     .build();
         }
-        return MessageMarkedAsRemoved
+        return MessageMarkedAsDeleted
                 .newBuilder()
                 .setId(c.getId())
                 .setChat(c.getChat())
@@ -128,7 +128,7 @@ public final class MessageAggregate extends Aggregate<MessageId, Message, Messag
     }
 
     @Apply
-    private void event(MessageMarkedAsRemoved e) {
+    private void event(MessageMarkedAsDeleted e) {
         setDeleted(true);
     }
 }

--- a/server/src/main/java/io/spine/examples/chatspn/server/message/MessageAggregate.java
+++ b/server/src/main/java/io/spine/examples/chatspn/server/message/MessageAggregate.java
@@ -111,7 +111,7 @@ public final class MessageAggregate extends Aggregate<MessageId, Message, Messag
      */
     @Assign
     MessageMarkedAsRemoved handle(MarkMessageAsRemoved c) throws MessageCannotBeMarkedAsRemoved {
-        if (!state().hasId() || state().getIsRemoved()) {
+        if (!state().hasId() || isDeleted()) {
             throw MessageCannotBeMarkedAsRemoved
                     .newBuilder()
                     .setId(c.getId())
@@ -129,6 +129,6 @@ public final class MessageAggregate extends Aggregate<MessageId, Message, Messag
 
     @Apply
     private void event(MessageMarkedAsRemoved e) {
-        builder().setIsRemoved(true);
+        setDeleted(true);
     }
 }

--- a/server/src/main/java/io/spine/examples/chatspn/server/message/MessageRemovalProcess.java
+++ b/server/src/main/java/io/spine/examples/chatspn/server/message/MessageRemovalProcess.java
@@ -66,9 +66,7 @@ public final class MessageRemovalProcess
     @Command
     MarkMessageAsDeleted on(RemoveMessage c, CommandContext ctx) throws MessageCannotBeRemoved {
         builder().setId(c.getId());
-        ChatMembers chatMembers = projectionReader
-                .read(ImmutableSet.of(c.getChat()), ctx.getActorContext())
-                .get(0);
+        ChatMembers chatMembers = readMembers(c.getChat(), ctx);
         if (chatMembers.getMemberList()
                        .contains(c.getUser())) {
             return MarkMessageAsDeleted
@@ -116,5 +114,11 @@ public final class MessageRemovalProcess
 
     void inject(ProjectionReader<ChatId, ChatMembers> reader) {
         projectionReader = reader;
+    }
+
+    private ChatMembers readMembers(ChatId id, CommandContext ctx) {
+        return projectionReader
+                .read(ImmutableSet.of(id), ctx.getActorContext())
+                .get(0);
     }
 }

--- a/server/src/main/java/io/spine/examples/chatspn/server/message/MessageRemovalProcess.java
+++ b/server/src/main/java/io/spine/examples/chatspn/server/message/MessageRemovalProcess.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2023, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.examples.chatspn.server.message;
+
+import com.google.common.collect.ImmutableSet;
+import io.spine.core.CommandContext;
+import io.spine.examples.chatspn.ChatId;
+import io.spine.examples.chatspn.MessageId;
+import io.spine.examples.chatspn.chat.ChatMembers;
+import io.spine.examples.chatspn.message.MessageRemoval;
+import io.spine.examples.chatspn.message.command.MarkMessageAsRemoved;
+import io.spine.examples.chatspn.message.command.RemoveMessage;
+import io.spine.examples.chatspn.message.event.MessageMarkedAsRemoved;
+import io.spine.examples.chatspn.message.event.MessageRemovalFailed;
+import io.spine.examples.chatspn.message.event.MessageRemoved;
+import io.spine.examples.chatspn.message.rejection.MessageCannotBeRemoved;
+import io.spine.examples.chatspn.message.rejection.RemovalRejections.MessageCannotBeMarkedAsRemoved;
+import io.spine.examples.chatspn.server.ProjectionReader;
+import io.spine.server.command.Command;
+import io.spine.server.event.React;
+import io.spine.server.procman.ProcessManager;
+import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
+
+/**
+ * Coordinates the message removal.
+ */
+public final class MessageRemovalProcess
+        extends ProcessManager<MessageId, MessageRemoval, MessageRemoval.Builder> {
+
+    /**
+     * Reads chat members per chat.
+     */
+    @MonotonicNonNull
+    private ProjectionReader<ChatId, ChatMembers> projectionReader;
+
+    /**
+     * Issues a command to mark message as removed.
+     *
+     * @throws MessageCannotBeRemoved
+     *         if the message remover is not a chat member
+     */
+    @Command
+    MarkMessageAsRemoved on(RemoveMessage c, CommandContext ctx) throws MessageCannotBeRemoved {
+        builder().setId(c.getId());
+        ChatMembers chatMembers = projectionReader
+                .read(ImmutableSet.of(c.getChat()), ctx.getActorContext())
+                .get(0);
+        if (chatMembers.getMemberList()
+                       .contains(c.getUser())) {
+            return MarkMessageAsRemoved
+                    .newBuilder()
+                    .setId(c.getId())
+                    .setChat(c.getChat())
+                    .setUser(c.getUser())
+                    .vBuild();
+        }
+        throw MessageCannotBeRemoved
+                .newBuilder()
+                .setId(c.getId())
+                .setChat(c.getChat())
+                .setUser(c.getUser())
+                .build();
+    }
+
+    /**
+     * Archives the process when the message was removed.
+     */
+    @React
+    MessageRemoved on(MessageMarkedAsRemoved e) {
+        setArchived(true);
+        return MessageRemoved
+                .newBuilder()
+                .setId(e.getId())
+                .setChat(e.getChat())
+                .setUser(e.getUser())
+                .vBuild();
+    }
+
+    /**
+     * Archives the process when the message removal failed.
+     */
+    @React
+    MessageRemovalFailed on(MessageCannotBeMarkedAsRemoved e) {
+        setArchived(true);
+        return MessageRemovalFailed
+                .newBuilder()
+                .setId(e.getId())
+                .setChat(e.getChat())
+                .setUser(e.getUser())
+                .vBuild();
+    }
+
+    void inject(ProjectionReader<ChatId, ChatMembers> reader) {
+        projectionReader = reader;
+    }
+}

--- a/server/src/main/java/io/spine/examples/chatspn/server/message/MessageRemovalProcess.java
+++ b/server/src/main/java/io/spine/examples/chatspn/server/message/MessageRemovalProcess.java
@@ -32,7 +32,7 @@ import io.spine.examples.chatspn.ChatId;
 import io.spine.examples.chatspn.MessageId;
 import io.spine.examples.chatspn.chat.ChatMembers;
 import io.spine.examples.chatspn.message.MessageRemoval;
-import io.spine.examples.chatspn.message.command.MarkMessageAsRemoved;
+import io.spine.examples.chatspn.message.command.MarkMessageAsDeleted;
 import io.spine.examples.chatspn.message.command.RemoveMessage;
 import io.spine.examples.chatspn.message.event.MessageMarkedAsDeleted;
 import io.spine.examples.chatspn.message.event.MessageRemovalFailed;
@@ -64,14 +64,14 @@ public final class MessageRemovalProcess
      *         if the message remover is not a chat member
      */
     @Command
-    MarkMessageAsRemoved on(RemoveMessage c, CommandContext ctx) throws MessageCannotBeRemoved {
+    MarkMessageAsDeleted on(RemoveMessage c, CommandContext ctx) throws MessageCannotBeRemoved {
         builder().setId(c.getId());
         ChatMembers chatMembers = projectionReader
                 .read(ImmutableSet.of(c.getChat()), ctx.getActorContext())
                 .get(0);
         if (chatMembers.getMemberList()
                        .contains(c.getUser())) {
-            return MarkMessageAsRemoved
+            return MarkMessageAsDeleted
                     .newBuilder()
                     .setId(c.getId())
                     .setChat(c.getChat())

--- a/server/src/main/java/io/spine/examples/chatspn/server/message/MessageRemovalProcess.java
+++ b/server/src/main/java/io/spine/examples/chatspn/server/message/MessageRemovalProcess.java
@@ -34,11 +34,11 @@ import io.spine.examples.chatspn.chat.ChatMembers;
 import io.spine.examples.chatspn.message.MessageRemoval;
 import io.spine.examples.chatspn.message.command.MarkMessageAsRemoved;
 import io.spine.examples.chatspn.message.command.RemoveMessage;
-import io.spine.examples.chatspn.message.event.MessageMarkedAsRemoved;
+import io.spine.examples.chatspn.message.event.MessageMarkedAsDeleted;
 import io.spine.examples.chatspn.message.event.MessageRemovalFailed;
 import io.spine.examples.chatspn.message.event.MessageRemoved;
 import io.spine.examples.chatspn.message.rejection.MessageCannotBeRemoved;
-import io.spine.examples.chatspn.message.rejection.RemovalRejections.MessageCannotBeMarkedAsRemoved;
+import io.spine.examples.chatspn.message.rejection.RemovalRejections.MessageCannotBeMarkedAsDeleted;
 import io.spine.examples.chatspn.server.ProjectionReader;
 import io.spine.server.command.Command;
 import io.spine.server.event.React;
@@ -58,7 +58,7 @@ public final class MessageRemovalProcess
     private ProjectionReader<ChatId, ChatMembers> projectionReader;
 
     /**
-     * Issues a command to mark message as removed.
+     * Issues a command to mark message as deleted.
      *
      * @throws MessageCannotBeRemoved
      *         if the message remover is not a chat member
@@ -90,7 +90,7 @@ public final class MessageRemovalProcess
      * Archives the process when the message was removed.
      */
     @React
-    MessageRemoved on(MessageMarkedAsRemoved e) {
+    MessageRemoved on(MessageMarkedAsDeleted e) {
         setArchived(true);
         return MessageRemoved
                 .newBuilder()
@@ -104,7 +104,7 @@ public final class MessageRemovalProcess
      * Archives the process when the message removal failed.
      */
     @React
-    MessageRemovalFailed on(MessageCannotBeMarkedAsRemoved e) {
+    MessageRemovalFailed on(MessageCannotBeMarkedAsDeleted e) {
         setArchived(true);
         return MessageRemovalFailed
                 .newBuilder()

--- a/server/src/main/java/io/spine/examples/chatspn/server/message/MessageRemovalRepository.java
+++ b/server/src/main/java/io/spine/examples/chatspn/server/message/MessageRemovalRepository.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2023, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.examples.chatspn.server.message;
+
+import com.google.errorprone.annotations.OverridingMethodsMustInvokeSuper;
+import io.spine.examples.chatspn.MessageId;
+import io.spine.examples.chatspn.chat.ChatMembers;
+import io.spine.examples.chatspn.message.MessageRemoval;
+import io.spine.examples.chatspn.message.event.MessageMarkedAsRemoved;
+import io.spine.examples.chatspn.message.rejection.RemovalRejections.MessageCannotBeMarkedAsRemoved;
+import io.spine.examples.chatspn.server.ProjectionReader;
+import io.spine.server.procman.ProcessManagerRepository;
+import io.spine.server.route.EventRouting;
+
+import static io.spine.server.route.EventRoute.withId;
+
+/**
+ * Manages instances of {@link MessageRemovalProcess}.
+ */
+public final class MessageRemovalRepository
+        extends ProcessManagerRepository<MessageId, MessageRemovalProcess, MessageRemoval> {
+
+    @OverridingMethodsMustInvokeSuper
+    @Override
+    protected void setupEventRouting(EventRouting<MessageId> routing) {
+        super.setupEventRouting(routing);
+        routing.route(MessageMarkedAsRemoved.class, (event, context) -> withId(event.getId()))
+               .route(MessageCannotBeMarkedAsRemoved.class,
+                      (event, context) -> withId(event.getId()));
+    }
+
+    @OverridingMethodsMustInvokeSuper
+    @Override
+    protected void configure(MessageRemovalProcess p) {
+        super.configure(p);
+        p.inject(new ProjectionReader<>(context().stand(), ChatMembers.class));
+    }
+}

--- a/server/src/main/java/io/spine/examples/chatspn/server/message/MessageRemovalRepository.java
+++ b/server/src/main/java/io/spine/examples/chatspn/server/message/MessageRemovalRepository.java
@@ -30,8 +30,8 @@ import com.google.errorprone.annotations.OverridingMethodsMustInvokeSuper;
 import io.spine.examples.chatspn.MessageId;
 import io.spine.examples.chatspn.chat.ChatMembers;
 import io.spine.examples.chatspn.message.MessageRemoval;
-import io.spine.examples.chatspn.message.event.MessageMarkedAsRemoved;
-import io.spine.examples.chatspn.message.rejection.RemovalRejections.MessageCannotBeMarkedAsRemoved;
+import io.spine.examples.chatspn.message.event.MessageMarkedAsDeleted;
+import io.spine.examples.chatspn.message.rejection.RemovalRejections.MessageCannotBeMarkedAsDeleted;
 import io.spine.examples.chatspn.server.ProjectionReader;
 import io.spine.server.procman.ProcessManagerRepository;
 import io.spine.server.route.EventRouting;
@@ -48,8 +48,8 @@ public final class MessageRemovalRepository
     @Override
     protected void setupEventRouting(EventRouting<MessageId> routing) {
         super.setupEventRouting(routing);
-        routing.route(MessageMarkedAsRemoved.class, (event, context) -> withId(event.getId()))
-               .route(MessageCannotBeMarkedAsRemoved.class,
+        routing.route(MessageMarkedAsDeleted.class, (event, context) -> withId(event.getId()))
+               .route(MessageCannotBeMarkedAsDeleted.class,
                       (event, context) -> withId(event.getId()));
     }
 

--- a/server/src/test/java/io/spine/examples/chatspn/server/given/MessageRemovalTestEnv.java
+++ b/server/src/test/java/io/spine/examples/chatspn/server/given/MessageRemovalTestEnv.java
@@ -110,7 +110,6 @@ public final class MessageRemovalTestEnv {
                 .setId(c.getId())
                 .setChat(c.getChat())
                 .setUser(c.getUser())
-                .setIsRemoved(true)
                 .buildPartial();
         return state;
     }

--- a/server/src/test/java/io/spine/examples/chatspn/server/given/MessageRemovalTestEnv.java
+++ b/server/src/test/java/io/spine/examples/chatspn/server/given/MessageRemovalTestEnv.java
@@ -30,10 +30,10 @@ import io.spine.core.UserId;
 import io.spine.examples.chatspn.MessageId;
 import io.spine.examples.chatspn.message.Message;
 import io.spine.examples.chatspn.message.command.RemoveMessage;
-import io.spine.examples.chatspn.message.event.MessageMarkedAsRemoved;
+import io.spine.examples.chatspn.message.event.MessageMarkedAsDeleted;
 import io.spine.examples.chatspn.message.event.MessageRemovalFailed;
 import io.spine.examples.chatspn.message.event.MessageRemoved;
-import io.spine.examples.chatspn.message.rejection.RemovalRejections.MessageCannotBeMarkedAsRemoved;
+import io.spine.examples.chatspn.message.rejection.RemovalRejections.MessageCannotBeMarkedAsDeleted;
 import io.spine.examples.chatspn.message.rejection.RemovalRejections.MessageCannotBeRemoved;
 
 public final class MessageRemovalTestEnv {
@@ -94,8 +94,8 @@ public final class MessageRemovalTestEnv {
         return event;
     }
 
-    public static MessageMarkedAsRemoved messageMarkedAsRemovedFrom(RemoveMessage c) {
-        MessageMarkedAsRemoved event = MessageMarkedAsRemoved
+    public static MessageMarkedAsDeleted messageMarkedAsDeletedFrom(RemoveMessage c) {
+        MessageMarkedAsDeleted event = MessageMarkedAsDeleted
                 .newBuilder()
                 .setId(c.getId())
                 .setChat(c.getChat())
@@ -124,9 +124,9 @@ public final class MessageRemovalTestEnv {
         return rejection;
     }
 
-    public static MessageCannotBeMarkedAsRemoved messageCannotBeMarkedAsRemovedFrom(
+    public static MessageCannotBeMarkedAsDeleted messageCannotBeMarkedAsRemovedFrom(
             RemoveMessage c) {
-        MessageCannotBeMarkedAsRemoved rejection = MessageCannotBeMarkedAsRemoved
+        MessageCannotBeMarkedAsDeleted rejection = MessageCannotBeMarkedAsDeleted
                 .newBuilder()
                 .setId(c.getId())
                 .setChat(c.getChat())

--- a/server/src/test/java/io/spine/examples/chatspn/server/given/MessageRemovalTestEnv.java
+++ b/server/src/test/java/io/spine/examples/chatspn/server/given/MessageRemovalTestEnv.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2023, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.examples.chatspn.server.given;
+
+import io.spine.core.UserId;
+import io.spine.examples.chatspn.MessageId;
+import io.spine.examples.chatspn.message.Message;
+import io.spine.examples.chatspn.message.command.RemoveMessage;
+import io.spine.examples.chatspn.message.event.MessageMarkedAsRemoved;
+import io.spine.examples.chatspn.message.event.MessageRemovalFailed;
+import io.spine.examples.chatspn.message.event.MessageRemoved;
+import io.spine.examples.chatspn.message.rejection.RemovalRejections.MessageCannotBeMarkedAsRemoved;
+import io.spine.examples.chatspn.message.rejection.RemovalRejections.MessageCannotBeRemoved;
+
+public final class MessageRemovalTestEnv {
+
+    /**
+     * Prevents class instantiation.
+     */
+    private MessageRemovalTestEnv() {
+    }
+
+    public static RemoveMessage removeMessageCommand(Message message) {
+        RemoveMessage command = RemoveMessage
+                .newBuilder()
+                .setId(message.getId())
+                .setChat(message.getChat())
+                .setUser(message.getUser())
+                .vBuild();
+        return command;
+    }
+
+    public static RemoveMessage removeMessageCommandWith(Message message, UserId userId) {
+        RemoveMessage command = RemoveMessage
+                .newBuilder()
+                .setId(message.getId())
+                .setChat(message.getChat())
+                .setUser(userId)
+                .vBuild();
+        return command;
+    }
+
+    public static RemoveMessage removeMessageCommandWith(Message message, MessageId messageId) {
+        RemoveMessage command = RemoveMessage
+                .newBuilder()
+                .setId(messageId)
+                .setChat(message.getChat())
+                .setUser(message.getUser())
+                .vBuild();
+        return command;
+    }
+
+    public static MessageRemoved messageRemovedFrom(RemoveMessage c) {
+        MessageRemoved event = MessageRemoved
+                .newBuilder()
+                .setId(c.getId())
+                .setChat(c.getChat())
+                .setUser(c.getUser())
+                .vBuild();
+        return event;
+    }
+
+    public static MessageRemovalFailed messageRemovalFailedFrom(RemoveMessage c) {
+        MessageRemovalFailed event = MessageRemovalFailed
+                .newBuilder()
+                .setId(c.getId())
+                .setChat(c.getChat())
+                .setUser(c.getUser())
+                .vBuild();
+        return event;
+    }
+
+    public static MessageMarkedAsRemoved messageMarkedAsRemovedFrom(RemoveMessage c) {
+        MessageMarkedAsRemoved event = MessageMarkedAsRemoved
+                .newBuilder()
+                .setId(c.getId())
+                .setChat(c.getChat())
+                .setUser(c.getUser())
+                .vBuild();
+        return event;
+    }
+
+    public static Message messageFrom(RemoveMessage c) {
+        Message state = Message
+                .newBuilder()
+                .setId(c.getId())
+                .setChat(c.getChat())
+                .setUser(c.getUser())
+                .setIsRemoved(true)
+                .buildPartial();
+        return state;
+    }
+
+    public static MessageCannotBeRemoved messageCannotBeRemovedFrom(RemoveMessage c) {
+        MessageCannotBeRemoved rejection = MessageCannotBeRemoved
+                .newBuilder()
+                .setId(c.getId())
+                .setChat(c.getChat())
+                .setUser(c.getUser())
+                .vBuild();
+        return rejection;
+    }
+
+    public static MessageCannotBeMarkedAsRemoved messageCannotBeMarkedAsRemovedFrom(
+            RemoveMessage c) {
+        MessageCannotBeMarkedAsRemoved rejection = MessageCannotBeMarkedAsRemoved
+                .newBuilder()
+                .setId(c.getId())
+                .setChat(c.getChat())
+                .setUser(c.getUser())
+                .vBuild();
+        return rejection;
+    }
+}

--- a/server/src/test/java/io/spine/examples/chatspn/server/message/MessageRemovalTest.java
+++ b/server/src/test/java/io/spine/examples/chatspn/server/message/MessageRemovalTest.java
@@ -30,10 +30,10 @@ import io.spine.examples.chatspn.MessageId;
 import io.spine.examples.chatspn.chat.Chat;
 import io.spine.examples.chatspn.message.Message;
 import io.spine.examples.chatspn.message.command.RemoveMessage;
-import io.spine.examples.chatspn.message.event.MessageMarkedAsRemoved;
+import io.spine.examples.chatspn.message.event.MessageMarkedAsDeleted;
 import io.spine.examples.chatspn.message.event.MessageRemovalFailed;
 import io.spine.examples.chatspn.message.event.MessageRemoved;
-import io.spine.examples.chatspn.message.rejection.RemovalRejections.MessageCannotBeMarkedAsRemoved;
+import io.spine.examples.chatspn.message.rejection.RemovalRejections.MessageCannotBeMarkedAsDeleted;
 import io.spine.examples.chatspn.message.rejection.RemovalRejections.MessageCannotBeRemoved;
 import io.spine.examples.chatspn.server.ChatsContext;
 import io.spine.server.BoundedContextBuilder;
@@ -48,7 +48,7 @@ import static io.spine.examples.chatspn.server.given.MessageEditingTestEnv.sendR
 import static io.spine.examples.chatspn.server.given.MessageRemovalTestEnv.messageCannotBeMarkedAsRemovedFrom;
 import static io.spine.examples.chatspn.server.given.MessageRemovalTestEnv.messageCannotBeRemovedFrom;
 import static io.spine.examples.chatspn.server.given.MessageRemovalTestEnv.messageFrom;
-import static io.spine.examples.chatspn.server.given.MessageRemovalTestEnv.messageMarkedAsRemovedFrom;
+import static io.spine.examples.chatspn.server.given.MessageRemovalTestEnv.messageMarkedAsDeletedFrom;
 import static io.spine.examples.chatspn.server.given.MessageRemovalTestEnv.messageRemovalFailedFrom;
 import static io.spine.examples.chatspn.server.given.MessageRemovalTestEnv.messageRemovedFrom;
 import static io.spine.examples.chatspn.server.given.MessageRemovalTestEnv.removeMessageCommand;
@@ -135,39 +135,39 @@ final class MessageRemovalTest extends ContextAwareTest {
     class MessageAggregate {
 
         @Test
-        @DisplayName("`MessageMarkedAsRemoved`")
+        @DisplayName("`MessageMarkedAsDeleted`")
         void event() {
             Chat chat = createRandomChatIn(context());
             Message message = sendRandomMessageTo(chat, context());
             RemoveMessage command = removeMessageCommand(message);
             context().receivesCommand(command);
-            MessageMarkedAsRemoved expected = messageMarkedAsRemovedFrom(command);
+            MessageMarkedAsDeleted expected = messageMarkedAsDeletedFrom(command);
 
             context().assertEvents()
-                     .withType(MessageMarkedAsRemoved.class)
+                     .withType(MessageMarkedAsDeleted.class)
                      .message(0)
                      .isEqualTo(expected);
         }
 
         @Test
-        @DisplayName("`MessageCannotBeMarkedAsRemoved` rejection " +
+        @DisplayName("`MessageCannotBeMarkedAsDeleted` rejection " +
                 "if message with the given ID doesn't exist")
         void rejectBecauseNotExist() {
             Chat chat = createRandomChatIn(context());
             Message message = sendRandomMessageTo(chat, context());
             RemoveMessage command = removeMessageCommandWith(message, MessageId.generate());
             context().receivesCommand(command);
-            MessageCannotBeMarkedAsRemoved expected =
+            MessageCannotBeMarkedAsDeleted expected =
                     messageCannotBeMarkedAsRemovedFrom(command);
 
             context().assertEvents()
-                     .withType(MessageCannotBeMarkedAsRemoved.class)
+                     .withType(MessageCannotBeMarkedAsDeleted.class)
                      .message(0)
                      .isEqualTo(expected);
         }
 
         @Test
-        @DisplayName("`MessageCannotBeMarkedAsRemoved` rejection " +
+        @DisplayName("`MessageCannotBeMarkedAsDeleted` rejection " +
                 "if the message is already marked as removed")
         void rejectBecauseAlreadyRemoved() {
             Chat chat = createRandomChatIn(context());
@@ -175,11 +175,11 @@ final class MessageRemovalTest extends ContextAwareTest {
             RemoveMessage command = removeMessageCommand(message);
             context().receivesCommand(command);
             context().receivesCommand(command);
-            MessageCannotBeMarkedAsRemoved expected =
+            MessageCannotBeMarkedAsDeleted expected =
                     messageCannotBeMarkedAsRemovedFrom(command);
 
             context().assertEvents()
-                     .withType(MessageCannotBeMarkedAsRemoved.class)
+                     .withType(MessageCannotBeMarkedAsDeleted.class)
                      .message(0)
                      .isEqualTo(expected);
         }

--- a/server/src/test/java/io/spine/examples/chatspn/server/message/MessageRemovalTest.java
+++ b/server/src/test/java/io/spine/examples/chatspn/server/message/MessageRemovalTest.java
@@ -126,7 +126,7 @@ final class MessageRemovalTest extends ContextAwareTest {
 
     @Nested
     @DisplayName("lead `MessageAggregate` to emission of the")
-    class MessageAggregateSubTest {
+    class MessageAggregateBehaviour {
 
         @Test
         @DisplayName("`MessageMarkedAsDeleted`")

--- a/server/src/test/java/io/spine/examples/chatspn/server/message/MessageRemovalTest.java
+++ b/server/src/test/java/io/spine/examples/chatspn/server/message/MessageRemovalTest.java
@@ -65,7 +65,7 @@ final class MessageRemovalTest extends ContextAwareTest {
     @Test
     @DisplayName("emit a `MessageRemoved` event " +
             "if the process is finished successfully and archive itself")
-    void messageEditedEvent() {
+    void messageRemovedEvent() {
         Chat chat = createRandomChatIn(context());
         Message message = sendRandomMessageTo(chat, context());
         RemoveMessage command = removeMessageCommand(message);
@@ -98,7 +98,7 @@ final class MessageRemovalTest extends ContextAwareTest {
     @Test
     @DisplayName("reject with the `MessageCannotBeRemoved` " +
             "if the message remover is not the chat member")
-    void messageCannotBeEditedRejection() {
+    void messageCannotBeRemovedRejection() {
         Chat chat = createRandomChatIn(context());
         Message message = sendRandomMessageTo(chat, context());
         RemoveMessage command = removeMessageCommandWith(message, GivenUserId.generated());
@@ -114,7 +114,7 @@ final class MessageRemovalTest extends ContextAwareTest {
     @Test
     @DisplayName("emit a `MessageRemovalFailed` event " +
             "if message cannot be marked as removed and archive itself")
-    void messageNotEditedEvent() {
+    void messageRemovalFailedEvent() {
         Chat chat = createRandomChatIn(context());
         Message message = sendRandomMessageTo(chat, context());
         RemoveMessage command = removeMessageCommandWith(message, MessageId.generate());
@@ -169,7 +169,7 @@ final class MessageRemovalTest extends ContextAwareTest {
         @Test
         @DisplayName("`MessageCannotBeMarkedAsRemoved` rejection " +
                 "if the message is already marked as removed")
-        void rejectBecauseEditorNonOwner() {
+        void rejectBecauseAlreadyRemoved() {
             Chat chat = createRandomChatIn(context());
             Message message = sendRandomMessageTo(chat, context());
             RemoveMessage command = removeMessageCommand(message);

--- a/server/src/test/java/io/spine/examples/chatspn/server/message/MessageRemovalTest.java
+++ b/server/src/test/java/io/spine/examples/chatspn/server/message/MessageRemovalTest.java
@@ -64,7 +64,7 @@ final class MessageRemovalTest extends ContextAwareTest {
 
     @Test
     @DisplayName("emit a `MessageRemoved` event " +
-            "if the process is finished successfully and archive itself")
+            "if the process is finished successfully, and archive itself")
     void messageRemovedEvent() {
         Chat chat = createRandomChatIn(context());
         Message message = sendRandomMessageTo(chat, context());
@@ -110,7 +110,7 @@ final class MessageRemovalTest extends ContextAwareTest {
 
     @Test
     @DisplayName("emit a `MessageRemovalFailed` event " +
-            "if message cannot be marked as deleted and archive itself")
+            "if message cannot be marked as deleted, and archive itself")
     void messageRemovalFailedEvent() {
         Chat chat = createRandomChatIn(context());
         Message message = sendRandomMessageTo(chat, context());

--- a/server/src/test/java/io/spine/examples/chatspn/server/message/MessageRemovalTest.java
+++ b/server/src/test/java/io/spine/examples/chatspn/server/message/MessageRemovalTest.java
@@ -72,17 +72,14 @@ final class MessageRemovalTest extends ContextAwareTest {
         context().receivesCommand(command);
         MessageRemoved expected = messageRemovedFrom(command);
 
-        context().assertEvents()
-                 .withType(MessageRemoved.class)
-                 .message(0)
-                 .isEqualTo(expected);
+        context().assertEvent(expected);
         context().assertEntity(expected.getId(), MessageRemovalProcess.class)
                  .archivedFlag()
                  .isTrue();
     }
 
     @Test
-    @DisplayName("update a `Message` to the expected state")
+    @DisplayName("update a `MessageAggregate` to the expected state")
     void state() {
         Chat chat = createRandomChatIn(context());
         Message message = sendRandomMessageTo(chat, context());
@@ -93,6 +90,9 @@ final class MessageRemovalTest extends ContextAwareTest {
         context().assertState(expected.getId(), Message.class)
                  .comparingExpectedFieldsOnly()
                  .isEqualTo(expected);
+        context().assertEntity(expected.getId(), MessageAggregate.class)
+                 .deletedFlag()
+                 .isTrue();
     }
 
     @Test
@@ -105,15 +105,12 @@ final class MessageRemovalTest extends ContextAwareTest {
         context().receivesCommand(command);
         MessageCannotBeRemoved expected = messageCannotBeRemovedFrom(command);
 
-        context().assertEvents()
-                 .withType(MessageCannotBeRemoved.class)
-                 .message(0)
-                 .isEqualTo(expected);
+        context().assertEvent(expected);
     }
 
     @Test
     @DisplayName("emit a `MessageRemovalFailed` event " +
-            "if message cannot be marked as removed and archive itself")
+            "if message cannot be marked as deleted and archive itself")
     void messageRemovalFailedEvent() {
         Chat chat = createRandomChatIn(context());
         Message message = sendRandomMessageTo(chat, context());
@@ -121,10 +118,7 @@ final class MessageRemovalTest extends ContextAwareTest {
         context().receivesCommand(command);
         MessageRemovalFailed expected = messageRemovalFailedFrom(command);
 
-        context().assertEvents()
-                 .withType(MessageRemovalFailed.class)
-                 .message(0)
-                 .isEqualTo(expected);
+        context().assertEvent(expected);
         context().assertEntity(expected.getId(), MessageRemovalProcess.class)
                  .archivedFlag()
                  .isTrue();
@@ -132,7 +126,7 @@ final class MessageRemovalTest extends ContextAwareTest {
 
     @Nested
     @DisplayName("lead `MessageAggregate` to emission of the")
-    class MessageAggregate {
+    class MessageAggregateSubTest {
 
         @Test
         @DisplayName("`MessageMarkedAsDeleted`")
@@ -143,10 +137,7 @@ final class MessageRemovalTest extends ContextAwareTest {
             context().receivesCommand(command);
             MessageMarkedAsDeleted expected = messageMarkedAsDeletedFrom(command);
 
-            context().assertEvents()
-                     .withType(MessageMarkedAsDeleted.class)
-                     .message(0)
-                     .isEqualTo(expected);
+            context().assertEvent(expected);
         }
 
         @Test
@@ -160,15 +151,12 @@ final class MessageRemovalTest extends ContextAwareTest {
             MessageCannotBeMarkedAsDeleted expected =
                     messageCannotBeMarkedAsRemovedFrom(command);
 
-            context().assertEvents()
-                     .withType(MessageCannotBeMarkedAsDeleted.class)
-                     .message(0)
-                     .isEqualTo(expected);
+            context().assertEvent(expected);
         }
 
         @Test
         @DisplayName("`MessageCannotBeMarkedAsDeleted` rejection " +
-                "if the message is already marked as removed")
+                "if the message is already marked as deleted")
         void rejectBecauseAlreadyRemoved() {
             Chat chat = createRandomChatIn(context());
             Message message = sendRandomMessageTo(chat, context());
@@ -178,10 +166,7 @@ final class MessageRemovalTest extends ContextAwareTest {
             MessageCannotBeMarkedAsDeleted expected =
                     messageCannotBeMarkedAsRemovedFrom(command);
 
-            context().assertEvents()
-                     .withType(MessageCannotBeMarkedAsDeleted.class)
-                     .message(0)
-                     .isEqualTo(expected);
+            context().assertEvent(expected);
         }
     }
 }

--- a/server/src/test/java/io/spine/examples/chatspn/server/message/MessageRemovalTest.java
+++ b/server/src/test/java/io/spine/examples/chatspn/server/message/MessageRemovalTest.java
@@ -1,0 +1,187 @@
+/*
+ * Copyright 2023, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.examples.chatspn.server.message;
+
+import io.spine.examples.chatspn.MessageId;
+import io.spine.examples.chatspn.chat.Chat;
+import io.spine.examples.chatspn.message.Message;
+import io.spine.examples.chatspn.message.command.RemoveMessage;
+import io.spine.examples.chatspn.message.event.MessageMarkedAsRemoved;
+import io.spine.examples.chatspn.message.event.MessageRemovalFailed;
+import io.spine.examples.chatspn.message.event.MessageRemoved;
+import io.spine.examples.chatspn.message.rejection.RemovalRejections.MessageCannotBeMarkedAsRemoved;
+import io.spine.examples.chatspn.message.rejection.RemovalRejections.MessageCannotBeRemoved;
+import io.spine.examples.chatspn.server.ChatsContext;
+import io.spine.server.BoundedContextBuilder;
+import io.spine.testing.core.given.GivenUserId;
+import io.spine.testing.server.blackbox.ContextAwareTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static io.spine.examples.chatspn.server.given.MessageEditingTestEnv.createRandomChatIn;
+import static io.spine.examples.chatspn.server.given.MessageEditingTestEnv.sendRandomMessageTo;
+import static io.spine.examples.chatspn.server.given.MessageRemovalTestEnv.messageCannotBeMarkedAsRemovedFrom;
+import static io.spine.examples.chatspn.server.given.MessageRemovalTestEnv.messageCannotBeRemovedFrom;
+import static io.spine.examples.chatspn.server.given.MessageRemovalTestEnv.messageFrom;
+import static io.spine.examples.chatspn.server.given.MessageRemovalTestEnv.messageMarkedAsRemovedFrom;
+import static io.spine.examples.chatspn.server.given.MessageRemovalTestEnv.messageRemovalFailedFrom;
+import static io.spine.examples.chatspn.server.given.MessageRemovalTestEnv.messageRemovedFrom;
+import static io.spine.examples.chatspn.server.given.MessageRemovalTestEnv.removeMessageCommand;
+import static io.spine.examples.chatspn.server.given.MessageRemovalTestEnv.removeMessageCommandWith;
+
+@DisplayName("`MessageRemoval` should")
+final class MessageRemovalTest extends ContextAwareTest {
+
+    @Override
+    protected BoundedContextBuilder contextBuilder() {
+        return ChatsContext.newBuilder();
+    }
+
+    @Test
+    @DisplayName("emit a `MessageRemoved` event " +
+            "if the process is finished successfully and archive itself")
+    void messageEditedEvent() {
+        Chat chat = createRandomChatIn(context());
+        Message message = sendRandomMessageTo(chat, context());
+        RemoveMessage command = removeMessageCommand(message);
+        context().receivesCommand(command);
+        MessageRemoved expected = messageRemovedFrom(command);
+
+        context().assertEvents()
+                 .withType(MessageRemoved.class)
+                 .message(0)
+                 .isEqualTo(expected);
+        context().assertEntity(expected.getId(), MessageRemovalProcess.class)
+                 .archivedFlag()
+                 .isTrue();
+    }
+
+    @Test
+    @DisplayName("update a `Message` to the expected state")
+    void state() {
+        Chat chat = createRandomChatIn(context());
+        Message message = sendRandomMessageTo(chat, context());
+        RemoveMessage command = removeMessageCommand(message);
+        context().receivesCommand(command);
+        Message expected = messageFrom(command);
+
+        context().assertState(expected.getId(), Message.class)
+                 .comparingExpectedFieldsOnly()
+                 .isEqualTo(expected);
+    }
+
+    @Test
+    @DisplayName("reject with the `MessageCannotBeRemoved` " +
+            "if the message remover is not the chat member")
+    void messageCannotBeEditedRejection() {
+        Chat chat = createRandomChatIn(context());
+        Message message = sendRandomMessageTo(chat, context());
+        RemoveMessage command = removeMessageCommandWith(message, GivenUserId.generated());
+        context().receivesCommand(command);
+        MessageCannotBeRemoved expected = messageCannotBeRemovedFrom(command);
+
+        context().assertEvents()
+                 .withType(MessageCannotBeRemoved.class)
+                 .message(0)
+                 .isEqualTo(expected);
+    }
+
+    @Test
+    @DisplayName("emit a `MessageRemovalFailed` event " +
+            "if message cannot be marked as removed and archive itself")
+    void messageNotEditedEvent() {
+        Chat chat = createRandomChatIn(context());
+        Message message = sendRandomMessageTo(chat, context());
+        RemoveMessage command = removeMessageCommandWith(message, MessageId.generate());
+        context().receivesCommand(command);
+        MessageRemovalFailed expected = messageRemovalFailedFrom(command);
+
+        context().assertEvents()
+                 .withType(MessageRemovalFailed.class)
+                 .message(0)
+                 .isEqualTo(expected);
+        context().assertEntity(expected.getId(), MessageRemovalProcess.class)
+                 .archivedFlag()
+                 .isTrue();
+    }
+
+    @Nested
+    @DisplayName("lead `MessageAggregate` to emission of the")
+    class MessageAggregate {
+
+        @Test
+        @DisplayName("`MessageMarkedAsRemoved`")
+        void event() {
+            Chat chat = createRandomChatIn(context());
+            Message message = sendRandomMessageTo(chat, context());
+            RemoveMessage command = removeMessageCommand(message);
+            context().receivesCommand(command);
+            MessageMarkedAsRemoved expected = messageMarkedAsRemovedFrom(command);
+
+            context().assertEvents()
+                     .withType(MessageMarkedAsRemoved.class)
+                     .message(0)
+                     .isEqualTo(expected);
+        }
+
+        @Test
+        @DisplayName("`MessageCannotBeMarkedAsRemoved` rejection " +
+                "if message with the given ID doesn't exist")
+        void rejectBecauseNotExist() {
+            Chat chat = createRandomChatIn(context());
+            Message message = sendRandomMessageTo(chat, context());
+            RemoveMessage command = removeMessageCommandWith(message, MessageId.generate());
+            context().receivesCommand(command);
+            MessageCannotBeMarkedAsRemoved expected =
+                    messageCannotBeMarkedAsRemovedFrom(command);
+
+            context().assertEvents()
+                     .withType(MessageCannotBeMarkedAsRemoved.class)
+                     .message(0)
+                     .isEqualTo(expected);
+        }
+
+        @Test
+        @DisplayName("`MessageCannotBeMarkedAsRemoved` rejection " +
+                "if the message is already marked as removed")
+        void rejectBecauseEditorNonOwner() {
+            Chat chat = createRandomChatIn(context());
+            Message message = sendRandomMessageTo(chat, context());
+            RemoveMessage command = removeMessageCommand(message);
+            context().receivesCommand(command);
+            context().receivesCommand(command);
+            MessageCannotBeMarkedAsRemoved expected =
+                    messageCannotBeMarkedAsRemovedFrom(command);
+
+            context().assertEvents()
+                     .withType(MessageCannotBeMarkedAsRemoved.class)
+                     .message(0)
+                     .isEqualTo(expected);
+        }
+    }
+}


### PR DESCRIPTION
This PR adds an implementation of the message removal flow.

Message removal flow model:
![image](https://user-images.githubusercontent.com/106074440/228541360-b11dafd6-b57d-4742-8d6e-841ebd6b3068.png)
