### PR TITLE
Separate personal and group chat

### DIFF
--- a/model/src/main/proto/spine_examples/chatspn/chat/chat.proto
+++ b/model/src/main/proto/spine_examples/chatspn/chat/chat.proto
@@ -47,6 +47,14 @@ message Chat {
     // List of the chat members.
     repeated spine.core.UserId member = 2 [(required) = true, (distinct) = true];
 
+    // The type of the chat.
+    ChatType type = 3;
+
+    enum ChatType {
+        PERSONAL = 0;
+        GROUP = 1;
+    }
+
     // The name of the chat.
-    string name = 3;
+    string name = 4;
 }

--- a/model/src/main/proto/spine_examples/chatspn/chat/chat.proto
+++ b/model/src/main/proto/spine_examples/chatspn/chat/chat.proto
@@ -48,6 +48,18 @@ message Chat {
     repeated spine.core.UserId member = 2 [(required) = true, (distinct) = true];
 
     // The type of the chat.
+    //
+    // Personal chat is responsible for communication between only 2 users.
+    // Personal chat doesn't have a name, avatar, etc.
+    // Members in the personal chat have the same permissions.
+    // Members can't leave from personal chat, only delete it.
+    //
+    // Group chat is responsible for communication between 2 or more users.
+    // Group chat may have editable name, avatar, etc.
+    // Members in group chat may have different permissions.
+    // Members with the appropriate permissions can add new users to the group chat.
+    // Members can leave a group chat, and the chat is only deleted when the last member has left.
+    //
     ChatType type = 3;
 
     enum ChatType {

--- a/model/src/main/proto/spine_examples/chatspn/chat/chat.proto
+++ b/model/src/main/proto/spine_examples/chatspn/chat/chat.proto
@@ -63,8 +63,8 @@ message Chat {
     ChatType type = 3;
 
     enum ChatType {
-        PERSONAL = 0;
-        GROUP = 1;
+        CT_PERSONAL = 0;
+        CT_GROUP = 1;
     }
 
     // The name of the chat.

--- a/model/src/main/proto/spine_examples/chatspn/chat/commands.proto
+++ b/model/src/main/proto/spine_examples/chatspn/chat/commands.proto
@@ -37,8 +37,21 @@ option java_multiple_files = true;
 import "spine/core/user_id.proto";
 import "spine_examples/chatspn/identifiers.proto";
 
-// Tells to create a new chat.
-message CreateChat {
+// Tells to create a new personal chat.
+message CreatePersonalChat {
+
+    // The ID of the chat to create.
+    ChatId id = 1;
+
+    // The user who tells to create the chat.
+    spine.core.UserId creator = 2 [(required) = true];
+
+    // The user to include into the personal chat as a second member.
+    spine.core.UserId member = 3 [(required) = true];
+}
+
+// Tells to create a new group chat.
+message CreateGroupChat {
 
     // The ID of the chat to create.
     ChatId id = 1;
@@ -53,5 +66,5 @@ message CreateChat {
     repeated spine.core.UserId member = 3 [(required) = true, (distinct) = true];
 
     // The name of the chat to create.
-    string name = 4;
+    string name = 4 [(required) = true];
 }

--- a/model/src/main/proto/spine_examples/chatspn/chat/events.proto
+++ b/model/src/main/proto/spine_examples/chatspn/chat/events.proto
@@ -43,7 +43,7 @@ message PersonalChatCreated {
     // The ID of the created chat.
     ChatId id = 1;
 
-    // The user who was created the chat.
+    // The user who created the chat.
     spine.core.UserId creator = 2 [(required) = true];
 
     // The second member into the created personal chat.
@@ -56,7 +56,7 @@ message GroupChatCreated {
     // The ID of the created chat.
     ChatId id = 1;
 
-    // The user who was created the chat.
+    // The user who created the chat.
     spine.core.UserId creator = 2 [(required) = true];
 
     // Users who are included in the chat as members.

--- a/model/src/main/proto/spine_examples/chatspn/chat/events.proto
+++ b/model/src/main/proto/spine_examples/chatspn/chat/events.proto
@@ -37,8 +37,21 @@ option java_multiple_files = true;
 import "spine/core/user_id.proto";
 import "spine_examples/chatspn/identifiers.proto";
 
-// A new chat has been created.
-message ChatCreated {
+// A new personal chat has been created.
+message PersonalChatCreated {
+
+    // The ID of the created chat.
+    ChatId id = 1;
+
+    // The user who was created the chat.
+    spine.core.UserId creator = 2 [(required) = true];
+
+    // The second member into the created personal chat.
+    spine.core.UserId member = 3 [(required) = true];
+}
+
+// A new group chat has been created.
+message GroupChatCreated {
 
     // The ID of the created chat.
     ChatId id = 1;
@@ -53,5 +66,5 @@ message ChatCreated {
     repeated spine.core.UserId member = 3 [(required) = true, (distinct) = true];
 
     // The name of the created chat.
-    string name = 4;
+    string name = 4 [(required) = true];
 }

--- a/server/src/main/java/io/spine/examples/chatspn/server/chat/ChatAggregate.java
+++ b/server/src/main/java/io/spine/examples/chatspn/server/chat/ChatAggregate.java
@@ -72,6 +72,7 @@ public final class ChatAggregate extends Aggregate<ChatId, Chat, Chat.Builder> {
                 .setId(c.getId())
                 .setCreator(c.getCreator())
                 .addAllMember(c.getMemberList())
+                .setName(c.getName())
                 .vBuild();
     }
 

--- a/server/src/main/java/io/spine/examples/chatspn/server/chat/ChatAggregate.java
+++ b/server/src/main/java/io/spine/examples/chatspn/server/chat/ChatAggregate.java
@@ -59,7 +59,7 @@ public final class ChatAggregate extends Aggregate<ChatId, Chat, Chat.Builder> {
         builder().setId(e.getId())
                  .addMember(e.getCreator())
                  .addMember(e.getMember())
-                 .setType(Chat.ChatType.PERSONAL);
+                 .setType(Chat.ChatType.CT_PERSONAL);
     }
 
     /**
@@ -82,6 +82,6 @@ public final class ChatAggregate extends Aggregate<ChatId, Chat, Chat.Builder> {
                  .addMember(e.getCreator())
                  .addAllMember(e.getMemberList())
                  .setName(e.getName())
-                 .setType(Chat.ChatType.GROUP);
+                 .setType(Chat.ChatType.CT_GROUP);
     }
 }

--- a/server/src/main/java/io/spine/examples/chatspn/server/chat/ChatAggregate.java
+++ b/server/src/main/java/io/spine/examples/chatspn/server/chat/ChatAggregate.java
@@ -28,8 +28,10 @@ package io.spine.examples.chatspn.server.chat;
 
 import io.spine.examples.chatspn.ChatId;
 import io.spine.examples.chatspn.chat.Chat;
-import io.spine.examples.chatspn.chat.command.CreateChat;
-import io.spine.examples.chatspn.chat.event.ChatCreated;
+import io.spine.examples.chatspn.chat.command.CreateGroupChat;
+import io.spine.examples.chatspn.chat.command.CreatePersonalChat;
+import io.spine.examples.chatspn.chat.event.GroupChatCreated;
+import io.spine.examples.chatspn.chat.event.PersonalChatCreated;
 import io.spine.server.aggregate.Aggregate;
 import io.spine.server.aggregate.Apply;
 import io.spine.server.command.Assign;
@@ -40,24 +42,45 @@ import io.spine.server.command.Assign;
 public final class ChatAggregate extends Aggregate<ChatId, Chat, Chat.Builder> {
 
     /**
-     * Handles the command to create a chat.
+     * Handles the command to create a personal chat.
      */
     @Assign
-    ChatCreated handle(CreateChat c) {
-        return ChatCreated
+    PersonalChatCreated handle(CreatePersonalChat c) {
+        return PersonalChatCreated
                 .newBuilder()
                 .setId(c.getId())
                 .setCreator(c.getCreator())
-                .setName(c.getName())
+                .setMember(c.getMember())
+                .vBuild();
+    }
+
+    @Apply
+    private void event(PersonalChatCreated e) {
+        builder().setId(e.getId())
+                 .addMember(e.getCreator())
+                 .addMember(e.getMember())
+                 .setType(Chat.ChatType.PERSONAL);
+    }
+
+    /**
+     * Handles the command to create a group chat.
+     */
+    @Assign
+    GroupChatCreated handle(CreateGroupChat c) {
+        return GroupChatCreated
+                .newBuilder()
+                .setId(c.getId())
+                .setCreator(c.getCreator())
                 .addAllMember(c.getMemberList())
                 .vBuild();
     }
 
     @Apply
-    private void event(ChatCreated e) {
+    private void event(GroupChatCreated e) {
         builder().setId(e.getId())
                  .addMember(e.getCreator())
                  .addAllMember(e.getMemberList())
-                 .setName(e.getName());
+                 .setName(e.getName())
+                 .setType(Chat.ChatType.GROUP);
     }
 }

--- a/server/src/main/java/io/spine/examples/chatspn/server/chat/ChatAggregate.java
+++ b/server/src/main/java/io/spine/examples/chatspn/server/chat/ChatAggregate.java
@@ -36,6 +36,9 @@ import io.spine.server.aggregate.Aggregate;
 import io.spine.server.aggregate.Apply;
 import io.spine.server.command.Assign;
 
+import static io.spine.examples.chatspn.chat.Chat.ChatType.CT_GROUP;
+import static io.spine.examples.chatspn.chat.Chat.ChatType.CT_PERSONAL;
+
 /**
  * A chat between two or more users.
  */
@@ -59,7 +62,7 @@ public final class ChatAggregate extends Aggregate<ChatId, Chat, Chat.Builder> {
         builder().setId(e.getId())
                  .addMember(e.getCreator())
                  .addMember(e.getMember())
-                 .setType(Chat.ChatType.CT_PERSONAL);
+                 .setType(CT_PERSONAL);
     }
 
     /**
@@ -82,6 +85,6 @@ public final class ChatAggregate extends Aggregate<ChatId, Chat, Chat.Builder> {
                  .addMember(e.getCreator())
                  .addAllMember(e.getMemberList())
                  .setName(e.getName())
-                 .setType(Chat.ChatType.CT_GROUP);
+                 .setType(CT_GROUP);
     }
 }

--- a/server/src/main/java/io/spine/examples/chatspn/server/chat/ChatMembersProjection.java
+++ b/server/src/main/java/io/spine/examples/chatspn/server/chat/ChatMembersProjection.java
@@ -29,7 +29,8 @@ package io.spine.examples.chatspn.server.chat;
 import io.spine.core.Subscribe;
 import io.spine.examples.chatspn.ChatId;
 import io.spine.examples.chatspn.chat.ChatMembers;
-import io.spine.examples.chatspn.chat.event.ChatCreated;
+import io.spine.examples.chatspn.chat.event.GroupChatCreated;
+import io.spine.examples.chatspn.chat.event.PersonalChatCreated;
 import io.spine.server.projection.Projection;
 
 /**
@@ -39,9 +40,16 @@ public final class ChatMembersProjection
         extends Projection<ChatId, ChatMembers, ChatMembers.Builder> {
 
     @Subscribe
-    void on(ChatCreated e) {
+    void on(PersonalChatCreated e) {
         builder().setId(e.getId())
-                 .addAllMember(e.getMemberList())
-                 .addMember(e.getCreator());
+                 .addMember(e.getCreator())
+                 .addMember(e.getMember());
+    }
+
+    @Subscribe
+    void on(GroupChatCreated e) {
+        builder().setId(e.getId())
+                 .addMember(e.getCreator())
+                 .addAllMember(e.getMemberList());
     }
 }

--- a/server/src/main/java/io/spine/examples/chatspn/server/chat/ChatMembersRepository.java
+++ b/server/src/main/java/io/spine/examples/chatspn/server/chat/ChatMembersRepository.java
@@ -29,7 +29,8 @@ package io.spine.examples.chatspn.server.chat;
 import com.google.errorprone.annotations.OverridingMethodsMustInvokeSuper;
 import io.spine.examples.chatspn.ChatId;
 import io.spine.examples.chatspn.chat.ChatMembers;
-import io.spine.examples.chatspn.chat.event.ChatCreated;
+import io.spine.examples.chatspn.chat.event.GroupChatCreated;
+import io.spine.examples.chatspn.chat.event.PersonalChatCreated;
 import io.spine.server.projection.ProjectionRepository;
 import io.spine.server.route.EventRouting;
 
@@ -45,6 +46,7 @@ public final class ChatMembersRepository
     @Override
     protected void setupEventRouting(EventRouting<ChatId> routing) {
         super.setupEventRouting(routing);
-        routing.route(ChatCreated.class, (event, context) -> withId(event.getId()));
+        routing.route(PersonalChatCreated.class, (event, context) -> withId(event.getId()))
+               .route(GroupChatCreated.class, (event, context) -> withId(event.getId()));
     }
 }

--- a/server/src/test/java/io/spine/examples/chatspn/server/chat/ChatMembersProjectionTest.java
+++ b/server/src/test/java/io/spine/examples/chatspn/server/chat/ChatMembersProjectionTest.java
@@ -40,7 +40,7 @@ import static io.spine.examples.chatspn.server.given.ChatTestEnv.createGroupChat
 import static io.spine.examples.chatspn.server.given.ChatTestEnv.createPersonalChatCommand;
 
 @DisplayName("`ChatMembersProjection` should")
-class ChatMembersProjectionTest extends ContextAwareTest {
+final class ChatMembersProjectionTest extends ContextAwareTest {
 
     @Override
     protected BoundedContextBuilder contextBuilder() {

--- a/server/src/test/java/io/spine/examples/chatspn/server/chat/ChatMembersProjectionTest.java
+++ b/server/src/test/java/io/spine/examples/chatspn/server/chat/ChatMembersProjectionTest.java
@@ -26,17 +26,18 @@
 
 package io.spine.examples.chatspn.server.chat;
 
-import io.spine.examples.chatspn.ChatId;
 import io.spine.examples.chatspn.chat.ChatMembers;
-import io.spine.examples.chatspn.chat.command.CreateChat;
+import io.spine.examples.chatspn.chat.command.CreateGroupChat;
+import io.spine.examples.chatspn.chat.command.CreatePersonalChat;
 import io.spine.examples.chatspn.server.ChatsContext;
 import io.spine.server.BoundedContextBuilder;
-import io.spine.testing.core.given.GivenUserId;
 import io.spine.testing.server.blackbox.ContextAwareTest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import static io.spine.testing.TestValues.randomString;
+import static io.spine.examples.chatspn.server.given.ChatMembersProjectionTestEnv.chatMembersFrom;
+import static io.spine.examples.chatspn.server.given.ChatTestEnv.createGroupChatCommand;
+import static io.spine.examples.chatspn.server.given.ChatTestEnv.createPersonalChatCommand;
 
 @DisplayName("`ChatMembersProjection` should")
 class ChatMembersProjectionTest extends ContextAwareTest {
@@ -47,23 +48,21 @@ class ChatMembersProjectionTest extends ContextAwareTest {
     }
 
     @Test
-    @DisplayName("display `ChatMembers`, as soon as `Chat` created")
-    void reactOnChatCreation() {
-        CreateChat command = CreateChat
-                .newBuilder()
-                .setId(ChatId.generate())
-                .setName(randomString())
-                .setCreator(GivenUserId.generated())
-                .addMember(GivenUserId.generated())
-                .vBuild();
+    @DisplayName("display `ChatMembers`, as soon as `PersonalChatCreated` is emitted")
+    void reactOnPersonalChatCreation() {
+        CreatePersonalChat command = createPersonalChatCommand();
         context().receivesCommand(command);
+        ChatMembers expected = chatMembersFrom(command);
 
-        ChatMembers expected = ChatMembers
-                .newBuilder()
-                .setId(command.getId())
-                .addAllMember(command.getMemberList())
-                .addMember(command.getCreator())
-                .vBuild();
+        context().assertState(command.getId(), expected);
+    }
+
+    @Test
+    @DisplayName("display `ChatMembers`, as soon as `GroupChatCreated` is emitted")
+    void reactOnGroupChatCreation() {
+        CreateGroupChat command = createGroupChatCommand();
+        context().receivesCommand(command);
+        ChatMembers expected = chatMembersFrom(command);
 
         context().assertState(command.getId(), expected);
     }

--- a/server/src/test/java/io/spine/examples/chatspn/server/chat/ChatMembersProjectionTest.java
+++ b/server/src/test/java/io/spine/examples/chatspn/server/chat/ChatMembersProjectionTest.java
@@ -36,8 +36,8 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import static io.spine.examples.chatspn.server.given.ChatMembersProjectionTestEnv.chatMembersFrom;
-import static io.spine.examples.chatspn.server.given.ChatTestEnv.createGroupChatCommand;
-import static io.spine.examples.chatspn.server.given.ChatTestEnv.createPersonalChatCommand;
+import static io.spine.examples.chatspn.server.chat.given.ChatTestEnv.createGroupChatCommand;
+import static io.spine.examples.chatspn.server.chat.given.ChatTestEnv.createPersonalChatCommand;
 
 @DisplayName("`ChatMembersProjection` should")
 final class ChatMembersProjectionTest extends ContextAwareTest {

--- a/server/src/test/java/io/spine/examples/chatspn/server/chat/ChatTest.java
+++ b/server/src/test/java/io/spine/examples/chatspn/server/chat/ChatTest.java
@@ -37,11 +37,11 @@ import io.spine.testing.server.blackbox.ContextAwareTest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import static io.spine.examples.chatspn.server.given.ChatTestEnv.chatFrom;
-import static io.spine.examples.chatspn.server.given.ChatTestEnv.createGroupChatCommand;
-import static io.spine.examples.chatspn.server.given.ChatTestEnv.createPersonalChatCommand;
-import static io.spine.examples.chatspn.server.given.ChatTestEnv.groupChatCreatedFrom;
-import static io.spine.examples.chatspn.server.given.ChatTestEnv.personalChatCreatedFrom;
+import static io.spine.examples.chatspn.server.chat.given.ChatTestEnv.chatFrom;
+import static io.spine.examples.chatspn.server.chat.given.ChatTestEnv.createGroupChatCommand;
+import static io.spine.examples.chatspn.server.chat.given.ChatTestEnv.createPersonalChatCommand;
+import static io.spine.examples.chatspn.server.chat.given.ChatTestEnv.groupChatCreatedFrom;
+import static io.spine.examples.chatspn.server.chat.given.ChatTestEnv.personalChatCreatedFrom;
 
 @DisplayName("`Chat` should")
 final class ChatTest extends ContextAwareTest {

--- a/server/src/test/java/io/spine/examples/chatspn/server/chat/ChatTest.java
+++ b/server/src/test/java/io/spine/examples/chatspn/server/chat/ChatTest.java
@@ -26,24 +26,24 @@
 
 package io.spine.examples.chatspn.server.chat;
 
-import io.spine.core.UserId;
-import io.spine.examples.chatspn.ChatId;
 import io.spine.examples.chatspn.chat.Chat;
-import io.spine.examples.chatspn.chat.command.CreateChat;
-import io.spine.examples.chatspn.chat.event.ChatCreated;
+import io.spine.examples.chatspn.chat.command.CreateGroupChat;
+import io.spine.examples.chatspn.chat.command.CreatePersonalChat;
+import io.spine.examples.chatspn.chat.event.GroupChatCreated;
+import io.spine.examples.chatspn.chat.event.PersonalChatCreated;
 import io.spine.examples.chatspn.server.ChatsContext;
 import io.spine.server.BoundedContextBuilder;
-import io.spine.testing.core.given.GivenUserId;
 import io.spine.testing.server.blackbox.ContextAwareTest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import java.util.ArrayList;
-
-import static io.spine.testing.TestValues.randomString;
+import static io.spine.examples.chatspn.server.given.ChatTestEnv.chatFrom;
+import static io.spine.examples.chatspn.server.given.ChatTestEnv.createGroupChatCommand;
+import static io.spine.examples.chatspn.server.given.ChatTestEnv.createPersonalChatCommand;
+import static io.spine.examples.chatspn.server.given.ChatTestEnv.personalChatCreatedFrom;
 
 @DisplayName("`Chat` should")
-class ChatTest extends ContextAwareTest {
+final class ChatTest extends ContextAwareTest {
 
     @Override
     protected BoundedContextBuilder contextBuilder() {
@@ -51,40 +51,27 @@ class ChatTest extends ContextAwareTest {
     }
 
     @Test
-    @DisplayName("allow creation and emit the `ChatCreated` event")
-    void creation() {
-        ArrayList<UserId> members = new ArrayList<>();
-        members.add(GivenUserId.generated());
-        members.add(GivenUserId.generated());
-
-        CreateChat command = CreateChat
-                .newBuilder()
-                .setId(ChatId.generate())
-                .setCreator(GivenUserId.generated())
-                .addAllMember(members)
-                .setName(randomString())
-                .vBuild();
-
+    @DisplayName("allow creation as personal and emit the `PersonalChatCreated` event")
+    void personalChatCreation() {
+        CreatePersonalChat command = createPersonalChatCommand();
         context().receivesCommand(command);
 
-        ChatCreated expectedEvent = ChatCreated
-                .newBuilder()
-                .setId(command.getId())
-                .setCreator(command.getCreator())
-                .addAllMember(command.getMemberList())
-                .setName(command.getName())
-                .vBuild();
-        Chat expectedState = Chat
-                .newBuilder()
-                .setId(command.getId())
-                .addMember(command.getCreator())
-                .addAllMember(command.getMemberList())
-                .setName(command.getName())
-                .vBuild();
+        PersonalChatCreated expectedEvent = personalChatCreatedFrom(command);
+        Chat expectedState = chatFrom(command);
 
-        context().assertEvents()
-                 .withType(ChatCreated.class)
-                 .hasSize(1);
+        context().assertEvent(expectedEvent);
+        context().assertState(command.getId(), expectedState);
+    }
+
+    @Test
+    @DisplayName("allow creation as group and emit the `GroupChatCreated` event")
+    void groupChatCreation() {
+        CreateGroupChat command = createGroupChatCommand();
+        context().receivesCommand(command);
+
+        GroupChatCreated expectedEvent = personalChatCreatedFrom(command);
+        Chat expectedState = chatFrom(command);
+
         context().assertEvent(expectedEvent);
         context().assertState(command.getId(), expectedState);
     }

--- a/server/src/test/java/io/spine/examples/chatspn/server/chat/ChatTest.java
+++ b/server/src/test/java/io/spine/examples/chatspn/server/chat/ChatTest.java
@@ -32,6 +32,7 @@ import io.spine.examples.chatspn.chat.command.CreatePersonalChat;
 import io.spine.examples.chatspn.chat.event.GroupChatCreated;
 import io.spine.examples.chatspn.chat.event.PersonalChatCreated;
 import io.spine.examples.chatspn.server.ChatsContext;
+import io.spine.examples.chatspn.server.given.ChatTestEnv;
 import io.spine.server.BoundedContextBuilder;
 import io.spine.testing.server.blackbox.ContextAwareTest;
 import org.junit.jupiter.api.DisplayName;
@@ -40,6 +41,7 @@ import org.junit.jupiter.api.Test;
 import static io.spine.examples.chatspn.server.given.ChatTestEnv.chatFrom;
 import static io.spine.examples.chatspn.server.given.ChatTestEnv.createGroupChatCommand;
 import static io.spine.examples.chatspn.server.given.ChatTestEnv.createPersonalChatCommand;
+import static io.spine.examples.chatspn.server.given.ChatTestEnv.groupChatCreatedFrom;
 import static io.spine.examples.chatspn.server.given.ChatTestEnv.personalChatCreatedFrom;
 
 @DisplayName("`Chat` should")
@@ -69,7 +71,7 @@ final class ChatTest extends ContextAwareTest {
         CreateGroupChat command = createGroupChatCommand();
         context().receivesCommand(command);
 
-        GroupChatCreated expectedEvent = personalChatCreatedFrom(command);
+        GroupChatCreated expectedEvent = groupChatCreatedFrom(command);
         Chat expectedState = chatFrom(command);
 
         context().assertEvent(expectedEvent);

--- a/server/src/test/java/io/spine/examples/chatspn/server/chat/ChatTest.java
+++ b/server/src/test/java/io/spine/examples/chatspn/server/chat/ChatTest.java
@@ -32,7 +32,6 @@ import io.spine.examples.chatspn.chat.command.CreatePersonalChat;
 import io.spine.examples.chatspn.chat.event.GroupChatCreated;
 import io.spine.examples.chatspn.chat.event.PersonalChatCreated;
 import io.spine.examples.chatspn.server.ChatsContext;
-import io.spine.examples.chatspn.server.given.ChatTestEnv;
 import io.spine.server.BoundedContextBuilder;
 import io.spine.testing.server.blackbox.ContextAwareTest;
 import org.junit.jupiter.api.DisplayName;

--- a/server/src/test/java/io/spine/examples/chatspn/server/chat/given/ChatTestEnv.java
+++ b/server/src/test/java/io/spine/examples/chatspn/server/chat/given/ChatTestEnv.java
@@ -24,7 +24,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package io.spine.examples.chatspn.server.given;
+package io.spine.examples.chatspn.server.chat.given;
 
 import io.spine.examples.chatspn.ChatId;
 import io.spine.examples.chatspn.chat.Chat;

--- a/server/src/test/java/io/spine/examples/chatspn/server/chat/given/package-info.java
+++ b/server/src/test/java/io/spine/examples/chatspn/server/chat/given/package-info.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2023, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+/**
+ * Provides API for creation test environment and signals for Chat.
+ */
+@CheckReturnValue
+@ParametersAreNonnullByDefault
+package io.spine.examples.chatspn.server.chat.given;
+
+import com.google.errorprone.annotations.CheckReturnValue;
+
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/server/src/test/java/io/spine/examples/chatspn/server/given/ChatMembersProjectionTestEnv.java
+++ b/server/src/test/java/io/spine/examples/chatspn/server/given/ChatMembersProjectionTestEnv.java
@@ -41,6 +41,7 @@ public final class ChatMembersProjectionTestEnv {
     public static ChatMembers chatMembersFrom(CreatePersonalChat c) {
         ChatMembers state = ChatMembers
                 .newBuilder()
+                .setId(c.getId())
                 .addMember(c.getCreator())
                 .addMember(c.getMember())
                 .vBuild();
@@ -50,6 +51,7 @@ public final class ChatMembersProjectionTestEnv {
     public static ChatMembers chatMembersFrom(CreateGroupChat c) {
         ChatMembers state = ChatMembers
                 .newBuilder()
+                .setId(c.getId())
                 .addMember(c.getCreator())
                 .addAllMember(c.getMemberList())
                 .vBuild();

--- a/server/src/test/java/io/spine/examples/chatspn/server/given/ChatMembersProjectionTestEnv.java
+++ b/server/src/test/java/io/spine/examples/chatspn/server/given/ChatMembersProjectionTestEnv.java
@@ -32,6 +32,12 @@ import io.spine.examples.chatspn.chat.command.CreatePersonalChat;
 
 public final class ChatMembersProjectionTestEnv {
 
+    /**
+     * Prevents class instantiation.
+     */
+    private ChatMembersProjectionTestEnv() {
+    }
+
     public static ChatMembers chatMembersFrom(CreatePersonalChat c) {
         ChatMembers state = ChatMembers
                 .newBuilder()

--- a/server/src/test/java/io/spine/examples/chatspn/server/given/ChatMembersProjectionTestEnv.java
+++ b/server/src/test/java/io/spine/examples/chatspn/server/given/ChatMembersProjectionTestEnv.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2023, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.examples.chatspn.server.given;
+
+import io.spine.examples.chatspn.chat.ChatMembers;
+import io.spine.examples.chatspn.chat.command.CreateGroupChat;
+import io.spine.examples.chatspn.chat.command.CreatePersonalChat;
+
+public final class ChatMembersProjectionTestEnv {
+
+    public static ChatMembers chatMembersFrom(CreatePersonalChat c) {
+        ChatMembers state = ChatMembers
+                .newBuilder()
+                .addMember(c.getCreator())
+                .addMember(c.getMember())
+                .vBuild();
+        return state;
+    }
+
+    public static ChatMembers chatMembersFrom(CreateGroupChat c) {
+        ChatMembers state = ChatMembers
+                .newBuilder()
+                .addMember(c.getCreator())
+                .addAllMember(c.getMemberList())
+                .vBuild();
+        return state;
+    }
+}

--- a/server/src/test/java/io/spine/examples/chatspn/server/given/ChatTestEnv.java
+++ b/server/src/test/java/io/spine/examples/chatspn/server/given/ChatTestEnv.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2023, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.examples.chatspn.server.given;
+
+import io.spine.examples.chatspn.ChatId;
+import io.spine.examples.chatspn.chat.Chat;
+import io.spine.examples.chatspn.chat.command.CreateGroupChat;
+import io.spine.examples.chatspn.chat.command.CreatePersonalChat;
+import io.spine.examples.chatspn.chat.event.GroupChatCreated;
+import io.spine.examples.chatspn.chat.event.PersonalChatCreated;
+import io.spine.testing.core.given.GivenUserId;
+
+import static io.spine.examples.chatspn.chat.Chat.ChatType.GROUP;
+import static io.spine.examples.chatspn.chat.Chat.ChatType.PERSONAL;
+import static io.spine.testing.TestValues.randomString;
+
+public final class ChatTestEnv {
+
+    public static CreatePersonalChat createPersonalChatCommand() {
+        CreatePersonalChat command = CreatePersonalChat
+                .newBuilder()
+                .setId(ChatId.generate())
+                .setCreator(GivenUserId.generated())
+                .setMember(GivenUserId.generated())
+                .vBuild();
+        return command;
+    }
+
+    public static PersonalChatCreated personalChatCreatedFrom(CreatePersonalChat c) {
+        PersonalChatCreated event = PersonalChatCreated
+                .newBuilder()
+                .setId(c.getId())
+                .setCreator(c.getCreator())
+                .setMember(c.getMember())
+                .vBuild();
+        return event;
+    }
+
+    public static Chat chatFrom(CreatePersonalChat c) {
+        Chat state = Chat
+                .newBuilder()
+                .setId(c.getId())
+                .setType(PERSONAL)
+                .addMember(c.getCreator())
+                .addMember(c.getMember())
+                .vBuild();
+        return state;
+    }
+
+    public static CreateGroupChat createGroupChatCommand() {
+        CreateGroupChat command = CreateGroupChat
+                .newBuilder()
+                .setId(ChatId.generate())
+                .setCreator(GivenUserId.generated())
+                .addMember(GivenUserId.generated())
+                .addMember(GivenUserId.generated())
+                .setName(randomString())
+                .vBuild();
+        return command;
+    }
+
+    public static GroupChatCreated personalChatCreatedFrom(CreateGroupChat c) {
+        GroupChatCreated event = GroupChatCreated
+                .newBuilder()
+                .setId(c.getId())
+                .setCreator(c.getCreator())
+                .addAllMember(c.getMemberList())
+                .setName(c.getName())
+                .vBuild();
+        return event;
+    }
+
+    public static Chat chatFrom(CreateGroupChat c) {
+        Chat state = Chat
+                .newBuilder()
+                .setId(c.getId())
+                .setType(GROUP)
+                .addMember(c.getCreator())
+                .addAllMember(c.getMemberList())
+                .setName(c.getName())
+                .vBuild();
+        return state;
+    }
+}

--- a/server/src/test/java/io/spine/examples/chatspn/server/given/ChatTestEnv.java
+++ b/server/src/test/java/io/spine/examples/chatspn/server/given/ChatTestEnv.java
@@ -83,7 +83,7 @@ public final class ChatTestEnv {
         return command;
     }
 
-    public static GroupChatCreated personalChatCreatedFrom(CreateGroupChat c) {
+    public static GroupChatCreated groupChatCreatedFrom(CreateGroupChat c) {
         GroupChatCreated event = GroupChatCreated
                 .newBuilder()
                 .setId(c.getId())

--- a/server/src/test/java/io/spine/examples/chatspn/server/given/ChatTestEnv.java
+++ b/server/src/test/java/io/spine/examples/chatspn/server/given/ChatTestEnv.java
@@ -40,6 +40,12 @@ import static io.spine.testing.TestValues.randomString;
 
 public final class ChatTestEnv {
 
+    /**
+     * Prevents class instantiation.
+     */
+    private ChatTestEnv() {
+    }
+
     public static CreatePersonalChat createPersonalChatCommand() {
         CreatePersonalChat command = CreatePersonalChat
                 .newBuilder()

--- a/server/src/test/java/io/spine/examples/chatspn/server/given/ChatTestEnv.java
+++ b/server/src/test/java/io/spine/examples/chatspn/server/given/ChatTestEnv.java
@@ -34,8 +34,8 @@ import io.spine.examples.chatspn.chat.event.GroupChatCreated;
 import io.spine.examples.chatspn.chat.event.PersonalChatCreated;
 import io.spine.testing.core.given.GivenUserId;
 
-import static io.spine.examples.chatspn.chat.Chat.ChatType.GROUP;
-import static io.spine.examples.chatspn.chat.Chat.ChatType.PERSONAL;
+import static io.spine.examples.chatspn.chat.Chat.ChatType.CT_GROUP;
+import static io.spine.examples.chatspn.chat.Chat.ChatType.CT_PERSONAL;
 import static io.spine.testing.TestValues.randomString;
 
 public final class ChatTestEnv {
@@ -70,7 +70,7 @@ public final class ChatTestEnv {
         Chat state = Chat
                 .newBuilder()
                 .setId(c.getId())
-                .setType(PERSONAL)
+                .setType(CT_PERSONAL)
                 .addMember(c.getCreator())
                 .addMember(c.getMember())
                 .vBuild();
@@ -104,7 +104,7 @@ public final class ChatTestEnv {
         Chat state = Chat
                 .newBuilder()
                 .setId(c.getId())
-                .setType(GROUP)
+                .setType(CT_GROUP)
                 .addMember(c.getCreator())
                 .addAllMember(c.getMemberList())
                 .setName(c.getName())

--- a/server/src/test/java/io/spine/examples/chatspn/server/given/MessageEditingTestEnv.java
+++ b/server/src/test/java/io/spine/examples/chatspn/server/given/MessageEditingTestEnv.java
@@ -30,7 +30,7 @@ import io.spine.core.UserId;
 import io.spine.examples.chatspn.ChatId;
 import io.spine.examples.chatspn.MessageId;
 import io.spine.examples.chatspn.chat.Chat;
-import io.spine.examples.chatspn.chat.command.CreateChat;
+import io.spine.examples.chatspn.chat.command.CreateGroupChat;
 import io.spine.examples.chatspn.message.Message;
 import io.spine.examples.chatspn.message.command.EditMessage;
 import io.spine.examples.chatspn.message.command.SendMessage;
@@ -60,7 +60,7 @@ public final class MessageEditingTestEnv {
                 .addMember(GivenUserId.generated())
                 .addMember(GivenUserId.generated())
                 .vBuild();
-        CreateChat createChat = CreateChat
+        CreateGroupChat createChat = CreateGroupChat
                 .newBuilder()
                 .setId(chat.getId())
                 .setName(chat.getName())

--- a/server/src/test/java/io/spine/examples/chatspn/server/given/MessageTestEnv.java
+++ b/server/src/test/java/io/spine/examples/chatspn/server/given/MessageTestEnv.java
@@ -30,7 +30,7 @@ import io.spine.core.UserId;
 import io.spine.examples.chatspn.ChatId;
 import io.spine.examples.chatspn.MessageId;
 import io.spine.examples.chatspn.chat.Chat;
-import io.spine.examples.chatspn.chat.command.CreateChat;
+import io.spine.examples.chatspn.chat.command.CreateGroupChat;
 import io.spine.examples.chatspn.message.Message;
 import io.spine.examples.chatspn.message.command.SendMessage;
 import io.spine.testing.core.given.GivenUserId;
@@ -54,7 +54,7 @@ public final class MessageTestEnv {
                 .addMember(GivenUserId.generated())
                 .setName(randomString())
                 .vBuild();
-        CreateChat command = CreateChat
+        CreateGroupChat command = CreateGroupChat
                 .newBuilder()
                 .setId(chat.getId())
                 .setCreator(chat.getMember(0))


### PR DESCRIPTION
This PR separates personal and group chat creation.

Personal and group chat creation flow models:
![image](https://user-images.githubusercontent.com/106074440/228319806-e65df727-af25-4385-98de-fcb8b9c9dd4c.png)
