### PR TITLE
Implement `UserChats` and `ChatPreview` projections

### DIFF
--- a/model/src/main/java/io/spine/examples/chatspn/BoundedContextName.java
+++ b/model/src/main/java/io/spine/examples/chatspn/BoundedContextName.java
@@ -27,7 +27,7 @@
 package io.spine.examples.chatspn;
 
 /**
- * Constant store for the {@link io.spine.server.BoundedContext} names in the ChatSPN.
+ * Names for the {@link io.spine.server.BoundedContext}s in the ChatSPN.
  */
 public final class BoundedContextName {
 

--- a/model/src/main/java/io/spine/examples/chatspn/BoundedContextName.java
+++ b/model/src/main/java/io/spine/examples/chatspn/BoundedContextName.java
@@ -24,15 +24,15 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-/**
- * This package contains basic data types of the ChatSPN application.
- */
-@BoundedContext(BoundedContextName.CHATS)
-@CheckReturnValue
-@ParametersAreNonnullByDefault
 package io.spine.examples.chatspn;
 
-import com.google.errorprone.annotations.CheckReturnValue;
-import io.spine.core.BoundedContext;
+/**
+ * Constant store for the {@link io.spine.server.BoundedContext} names in the ChatSPN.
+ */
+public final class BoundedContextName {
 
-import javax.annotation.ParametersAreNonnullByDefault;
+    public static final String CHATS = "Chats";
+
+    private BoundedContextName() {
+    }
+}

--- a/model/src/main/java/io/spine/examples/chatspn/BoundedContextNames.java
+++ b/model/src/main/java/io/spine/examples/chatspn/BoundedContextNames.java
@@ -27,7 +27,7 @@
 package io.spine.examples.chatspn;
 
 /**
- * Names for the {@link io.spine.server.BoundedContext}s in the ChatSPN.
+ * Names for the {@link io.spine.server.BoundedContext BoundedContext}s in the ChatSPN.
  */
 public final class BoundedContextNames {
 

--- a/model/src/main/java/io/spine/examples/chatspn/BoundedContextNames.java
+++ b/model/src/main/java/io/spine/examples/chatspn/BoundedContextNames.java
@@ -29,10 +29,10 @@ package io.spine.examples.chatspn;
 /**
  * Names for the {@link io.spine.server.BoundedContext}s in the ChatSPN.
  */
-public final class BoundedContextName {
+public final class BoundedContextNames {
 
     public static final String CHATS = "Chats";
 
-    private BoundedContextName() {
+    private BoundedContextNames() {
     }
 }

--- a/model/src/main/java/io/spine/examples/chatspn/package-info.java
+++ b/model/src/main/java/io/spine/examples/chatspn/package-info.java
@@ -27,7 +27,7 @@
 /**
  * This package contains basic data types of the ChatSPN application.
  */
-@BoundedContext(BoundedContextName.CHATS)
+@BoundedContext(CHATS)
 @CheckReturnValue
 @ParametersAreNonnullByDefault
 package io.spine.examples.chatspn;
@@ -36,3 +36,5 @@ import com.google.errorprone.annotations.CheckReturnValue;
 import io.spine.core.BoundedContext;
 
 import javax.annotation.ParametersAreNonnullByDefault;
+
+import static io.spine.examples.chatspn.BoundedContextNames.CHATS;

--- a/model/src/main/proto/spine_examples/chatspn/account/user_chats.proto
+++ b/model/src/main/proto/spine_examples/chatspn/account/user_chats.proto
@@ -39,13 +39,13 @@ import "spine/core/user_id.proto";
 import "spine_examples/chatspn/identifiers.proto";
 import "spine_examples/chatspn/chat/chat_preview.proto";
 
-// Previews of chats in which the user is a member.
+// Chats in which the user is a member.
 message UserChats {
     option (entity) = { kind: PROJECTION };
 
     // The ID of the user.
     spine.core.UserId id = 1;
 
-    // Chats the user is a member of.
+    // Previews of chats in which the user is a member.
     repeated spine_examples.chatspn.chat.ChatPreview chat = 2 [(distinct) = true];
 }

--- a/model/src/main/proto/spine_examples/chatspn/account/user_chats.proto
+++ b/model/src/main/proto/spine_examples/chatspn/account/user_chats.proto
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2023, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+syntax = "proto3";
+
+package spine_examples.chatspn.account;
+
+import "spine/options.proto";
+
+option (type_url_prefix) = "type.chatspn.spine.io";
+option java_package = "io.spine.examples.chatspn.account";
+option java_outer_classname = "UserChatsProto";
+option java_multiple_files = true;
+
+import "google/protobuf/timestamp.proto";
+import "spine/core/user_id.proto";
+import "spine_examples/chatspn/identifiers.proto";
+import "spine_examples/chatspn/chat/chat_preview.proto";
+
+// Previews of chats in which the user is a member.
+message UserChats {
+    option (entity) = { kind: PROJECTION };
+
+    // The ID of the user.
+    spine.core.UserId id = 1;
+
+    // Chats the user is a member of.
+    repeated spine_examples.chatspn.chat.ChatPreview chat = 2 [(distinct) = true];
+}

--- a/model/src/main/proto/spine_examples/chatspn/chat/chat_preview.proto
+++ b/model/src/main/proto/spine_examples/chatspn/chat/chat_preview.proto
@@ -54,40 +54,45 @@ message ChatPreview {
     // View of the chat.
     oneof view {
 
-        // Store view info about two members to display a view of another member for each user;
-        PersonalChatView personal_chat_view = 3;
+        // Store view info about two members to display a view of another member for each user.
+        PersonalChatView personal_chat = 3;
 
-        // Store same view info for all members.
-        GroupChatView group_chat_view = 4;
+        // Store the same view info of the group chat for all members.
+        GroupChatView group_chat = 4;
     }
+}
 
-    message PersonalChatView {
+// View of the group chat.
+message GroupChatView {
 
-        // The ID of the creator.
-        spine.core.UserId creator = 1 [(required) = true];
+    // Group chat name.
+    string name = 1;
+}
 
-        // The ID of the second member in the personal chat.
-        spine.core.UserId member = 2 [(required) = true];
-    }
+// View info about two members to display a view of another member
+// for each user in the personal chat.
+//
+message PersonalChatView {
 
-    message GroupChatView {
+    // The ID of the creator.
+    spine.core.UserId creator = 1 [(required) = true];
 
-        // Group chat name.
-        string name = 1;
-    }
+    // The ID of the second member in the personal chat.
+    spine.core.UserId member = 2 [(required) = true];
+}
 
-    message MessagePreview {
+// Single message preview.
+message MessagePreview {
 
-        // The ID of the message.
-        MessageId id = 1 [(required) = true];
+    // The ID of the message.
+    MessageId id = 1 [(required) = true];
 
-        // The ID of the user who posted this message.
-        spine.core.UserId user = 2 [(required) = true];
+    // The ID of the user who posted this message.
+    spine.core.UserId user = 2 [(required) = true];
 
-        // The message text content.
-        string content = 3 [(required) = true];
+    // The message text content.
+    string content = 3 [(required) = true];
 
-        // Time when this message was posted.
-        google.protobuf.Timestamp when_posted = 4 [(required) = true];
-    }
+    // Time when this message was posted.
+    google.protobuf.Timestamp when_posted = 4 [(required) = true];
 }

--- a/model/src/main/proto/spine_examples/chatspn/chat/chat_preview.proto
+++ b/model/src/main/proto/spine_examples/chatspn/chat/chat_preview.proto
@@ -69,7 +69,7 @@ message ChatPreview {
         // The ID of the creator.
         spine.core.UserId creator = 1 [(required) = true];
 
-        // The ID of the member in the personal chat.
+        // The ID of the second member in the personal chat.
         spine.core.UserId member = 2 [(required) = true];
     }
 

--- a/model/src/main/proto/spine_examples/chatspn/chat/chat_preview.proto
+++ b/model/src/main/proto/spine_examples/chatspn/chat/chat_preview.proto
@@ -51,16 +51,13 @@ message ChatPreview {
     // The last posted message in this chat.
     MessagePreview last_message = 2;
 
-    // Primary view of the chat (e.g. name).
-    //
-    // May be:
-    // - personal, store view info about two members to display
-    //   a view of another member for each user;
-    // - group, store same view info for all members.
+    // View of the chat.
     oneof view {
 
+        // Store view info about two members to display a view of another member for each user;
         PersonalChatView personal_chat_view = 3;
 
+        // Store same view info for all members.
         GroupChatView group_chat_view = 4;
     }
 

--- a/model/src/main/proto/spine_examples/chatspn/chat/chat_preview.proto
+++ b/model/src/main/proto/spine_examples/chatspn/chat/chat_preview.proto
@@ -67,16 +67,10 @@ message ChatPreview {
     message PersonalChatView {
 
         // The ID of the creator.
-        spine.core.UserId creator_id = 1;
-
-        // The name of the creator.
-        string creator_name = 2;
+        spine.core.UserId creator = 1 [(required) = true];
 
         // The ID of the member in the personal chat.
-        spine.core.UserId member_id = 3;
-
-        // The name of the second member in the personal chat.
-        string member_name = 4;
+        spine.core.UserId member = 2 [(required) = true];
     }
 
     message GroupChatView {

--- a/model/src/main/proto/spine_examples/chatspn/chat/chat_preview.proto
+++ b/model/src/main/proto/spine_examples/chatspn/chat/chat_preview.proto
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2023, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+syntax = "proto3";
+
+package spine_examples.chatspn.chat;
+
+import "spine/options.proto";
+
+option (type_url_prefix) = "type.chatspn.spine.io";
+option java_package = "io.spine.examples.chatspn.chat";
+option java_outer_classname = "ChatPreviewProto";
+option java_multiple_files = true;
+
+import "spine/core/user_id.proto";
+import "spine_examples/chatspn/identifiers.proto";
+import "spine_examples/chatspn/chat/chat.proto";
+import "spine_examples/chatspn/account/user_profile.proto";
+import "spine_examples/chatspn/message/message.proto";
+import "google/protobuf/timestamp.proto";
+
+// Single chat preview.
+message ChatPreview {
+    option (entity) = { kind: PROJECTION };
+
+    // The ID of the chat.
+    ChatId id = 1;
+
+    // The last posted message in this chat.
+    MessagePreview last_message = 2;
+
+    // Primary view of the chat (e.g. name).
+    //
+    // May be:
+    // - personal, store view info about two members to display
+    //   a view of another member for each user;
+    // - group, store same view info for all members.
+    oneof view {
+
+        PersonalChatView personal_chat_view = 3;
+
+        GroupChatView group_chat_view = 4;
+    }
+
+    message PersonalChatView {
+
+        // The ID of the creator.
+        spine.core.UserId creator_id = 1;
+
+        // The name of the creator.
+        string creator_name = 2;
+
+        // The ID of the member in the personal chat.
+        spine.core.UserId member_id = 3;
+
+        // The name of the second member in the personal chat.
+        string member_name = 4;
+    }
+
+    message GroupChatView {
+
+        // Group chat name.
+        string name = 1;
+    }
+
+    message MessagePreview {
+
+        // The ID of the message.
+        MessageId id = 1 [(required) = true];
+
+        // The ID of the user who posted this message.
+        spine.core.UserId user = 2 [(required) = true];
+
+        // The message text content.
+        string content = 3 [(required) = true];
+
+        // Time when this message was posted.
+        google.protobuf.Timestamp when_posted = 4 [(required) = true];
+    }
+}

--- a/model/src/main/proto/spine_examples/chatspn/chat/events.proto
+++ b/model/src/main/proto/spine_examples/chatspn/chat/events.proto
@@ -99,6 +99,9 @@ message MembersRemoved {
 
     // Members remaining in the chat.
     repeated spine.core.UserId remaining_member = 3 [(required) = true, (distinct) = true];
+
+    // Members removed from the chat.
+    repeated spine.core.UserId removed_member = 4 [(required) = true, (distinct) = true];
 }
 
 // User left the chat.

--- a/model/src/main/proto/spine_examples/chatspn/chat/events.proto
+++ b/model/src/main/proto/spine_examples/chatspn/chat/events.proto
@@ -78,11 +78,13 @@ message MembersAdded {
     // The ID of the chat in which members were added.
     ChatId id = 1;
 
+    string chat_name = 2 [(required) = true];
+
     // The user who added new members.
-    spine.core.UserId who_added = 2 [(required) = true];
+    spine.core.UserId who_added = 3 [(required) = true];
 
     // Users who were added to the chat as members.
-    repeated spine.core.UserId member = 3 [(required) = true, (distinct) = true];
+    repeated spine.core.UserId member = 4 [(required) = true, (distinct) = true];
 }
 
 // Members have been removed from the chat.

--- a/server/src/main/java/io/spine/examples/chatspn/server/ChatMembersReader.java
+++ b/server/src/main/java/io/spine/examples/chatspn/server/ChatMembersReader.java
@@ -67,7 +67,7 @@ public final class ChatMembersReader {
     /**
      * Returns a list of chat members.
      *
-     * <p>If the chat with the provided ID does not exist, just returns empty list.
+     * <p>If the chat with the provided ID does not exist, returns an empty list.
      */
     public ImmutableList<UserId> members(ChatId chat, ActorContext ctx) {
         ImmutableList<ChatMembers> projections = reader

--- a/server/src/main/java/io/spine/examples/chatspn/server/ChatMembersReader.java
+++ b/server/src/main/java/io/spine/examples/chatspn/server/ChatMembersReader.java
@@ -24,24 +24,24 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package io.spine.examples.chatspn.server.message;
+package io.spine.examples.chatspn.server;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+import io.spine.core.ActorContext;
 import io.spine.core.CommandContext;
 import io.spine.core.UserId;
 import io.spine.examples.chatspn.ChatId;
 import io.spine.examples.chatspn.chat.ChatMembers;
-import io.spine.examples.chatspn.server.ProjectionReader;
 
 /**
  * Provides an API to read the {@link ChatMembers} projection.
  */
-final class ChatMembersReader {
+public final class ChatMembersReader {
 
     private final ProjectionReader<ChatId, ChatMembers> reader;
 
-    ChatMembersReader(ProjectionReader<ChatId, ChatMembers> reader) {
+    public ChatMembersReader(ProjectionReader<ChatId, ChatMembers> reader) {
         this.reader = reader;
     }
 
@@ -52,7 +52,7 @@ final class ChatMembersReader {
      *
      * @return {@code true} in case user is a member of the chat, {@code false} otherwise
      */
-    boolean isMember(ChatId id, UserId userId, CommandContext ctx) {
+    public boolean isMember(ChatId id, UserId userId, CommandContext ctx) {
         ImmutableList<ChatMembers> projections =
                 reader.read(ImmutableSet.of(id), ctx.getActorContext());
         if (projections.isEmpty()) {
@@ -62,5 +62,20 @@ final class ChatMembersReader {
                                       .getMemberList()
                                       .contains(userId);
         return isMember;
+    }
+
+    /**
+     * Returns a list of chat members.
+     *
+     * <p>If the chat with the provided ID does not exist, just returns empty list.
+     */
+    public ImmutableList<UserId> members(ChatId chat, ActorContext ctx) {
+        ImmutableList<ChatMembers> projections = reader
+                .read(ImmutableSet.of(chat), ctx);
+        if (projections.isEmpty()) {
+            return ImmutableList.of();
+        }
+        return ImmutableList.copyOf(projections.get(0)
+                                               .getMemberList());
     }
 }

--- a/server/src/main/java/io/spine/examples/chatspn/server/ChatsContext.java
+++ b/server/src/main/java/io/spine/examples/chatspn/server/ChatsContext.java
@@ -29,10 +29,12 @@ package io.spine.examples.chatspn.server;
 import io.spine.examples.chatspn.server.account.AccountCreationRepository;
 import io.spine.examples.chatspn.server.account.ReservedEmailAggregate;
 import io.spine.examples.chatspn.server.account.UserAggregate;
+import io.spine.examples.chatspn.server.account.UserChatsRepository;
 import io.spine.examples.chatspn.server.account.UserProfileRepository;
 import io.spine.examples.chatspn.server.chat.ChatAggregate;
 import io.spine.examples.chatspn.server.chat.ChatDeletionRepository;
 import io.spine.examples.chatspn.server.chat.ChatMembersRepository;
+import io.spine.examples.chatspn.server.chat.ChatPreviewRepository;
 import io.spine.examples.chatspn.server.message.MessageAggregate;
 import io.spine.examples.chatspn.server.message.MessageEditingRepository;
 import io.spine.examples.chatspn.server.message.MessageRemovalRepository;
@@ -73,6 +75,8 @@ public final class ChatsContext {
                 .add(DefaultRepository.of(ReservedEmailAggregate.class))
                 .add(new AccountCreationRepository())
                 .add(new MessageViewRepository())
-                .add(new ChatDeletionRepository());
+                .add(new ChatDeletionRepository())
+                .add(new ChatPreviewRepository())
+                .add(new UserChatsRepository());
     }
 }

--- a/server/src/main/java/io/spine/examples/chatspn/server/ChatsContext.java
+++ b/server/src/main/java/io/spine/examples/chatspn/server/ChatsContext.java
@@ -44,7 +44,7 @@ import io.spine.server.BoundedContext;
 import io.spine.server.BoundedContextBuilder;
 import io.spine.server.DefaultRepository;
 
-import static io.spine.examples.chatspn.BoundedContextName.CHATS;
+import static io.spine.examples.chatspn.BoundedContextNames.CHATS;
 
 /**
  * Configures Chats Bounded Context with repositories.

--- a/server/src/main/java/io/spine/examples/chatspn/server/ChatsContext.java
+++ b/server/src/main/java/io/spine/examples/chatspn/server/ChatsContext.java
@@ -26,6 +26,7 @@
 
 package io.spine.examples.chatspn.server;
 
+import io.spine.examples.chatspn.BoundedContextName;
 import io.spine.examples.chatspn.server.account.AccountCreationRepository;
 import io.spine.examples.chatspn.server.account.ReservedEmailAggregate;
 import io.spine.examples.chatspn.server.account.UserAggregate;
@@ -49,8 +50,6 @@ import io.spine.server.DefaultRepository;
  */
 public final class ChatsContext {
 
-    static final String NAME = "Chats";
-
     /**
      * Prevents instantiation of this class.
      */
@@ -63,7 +62,7 @@ public final class ChatsContext {
      */
     public static BoundedContextBuilder newBuilder() {
         return BoundedContext
-                .singleTenant(NAME)
+                .singleTenant(BoundedContextName.CHATS)
                 .add(DefaultRepository.of(UserAggregate.class))
                 .add(DefaultRepository.of(ChatAggregate.class))
                 .add(DefaultRepository.of(MessageAggregate.class))

--- a/server/src/main/java/io/spine/examples/chatspn/server/ChatsContext.java
+++ b/server/src/main/java/io/spine/examples/chatspn/server/ChatsContext.java
@@ -26,7 +26,6 @@
 
 package io.spine.examples.chatspn.server;
 
-import io.spine.examples.chatspn.BoundedContextName;
 import io.spine.examples.chatspn.server.account.AccountCreationRepository;
 import io.spine.examples.chatspn.server.account.ReservedEmailAggregate;
 import io.spine.examples.chatspn.server.account.UserAggregate;
@@ -45,6 +44,8 @@ import io.spine.server.BoundedContext;
 import io.spine.server.BoundedContextBuilder;
 import io.spine.server.DefaultRepository;
 
+import static io.spine.examples.chatspn.BoundedContextName.CHATS;
+
 /**
  * Configures Chats Bounded Context with repositories.
  */
@@ -62,7 +63,7 @@ public final class ChatsContext {
      */
     public static BoundedContextBuilder newBuilder() {
         return BoundedContext
-                .singleTenant(BoundedContextName.CHATS)
+                .singleTenant(CHATS)
                 .add(DefaultRepository.of(UserAggregate.class))
                 .add(DefaultRepository.of(ChatAggregate.class))
                 .add(DefaultRepository.of(MessageAggregate.class))

--- a/server/src/main/java/io/spine/examples/chatspn/server/account/UserChatsProjection.java
+++ b/server/src/main/java/io/spine/examples/chatspn/server/account/UserChatsProjection.java
@@ -32,7 +32,9 @@ import io.spine.examples.chatspn.ChatId;
 import io.spine.examples.chatspn.account.UserChats;
 import io.spine.examples.chatspn.account.event.UserRegistered;
 import io.spine.examples.chatspn.chat.ChatPreview;
+import io.spine.examples.chatspn.chat.ChatPreview.GroupChatView;
 import io.spine.examples.chatspn.chat.event.ChatMarkedAsDeleted;
+import io.spine.examples.chatspn.chat.event.MembersAdded;
 import io.spine.examples.chatspn.chat.event.MembersRemoved;
 import io.spine.examples.chatspn.chat.event.UserLeftChat;
 import io.spine.server.projection.Projection;
@@ -67,6 +69,23 @@ public final class UserChatsProjection extends Projection<UserId, UserChats, Use
     @Subscribe
     void on(UserLeftChat e) {
         removeChat(e.getChat());
+    }
+
+    @Subscribe
+    void on(MembersAdded e) {
+        Optional<Integer> chatIndex = findChatIndex(e.getId());
+        if (!chatIndex.isPresent()) {
+            GroupChatView view = GroupChatView
+                    .newBuilder()
+                    .setName(e.getChatName())
+                    .vBuild();
+            ChatPreview chatPreview = ChatPreview
+                    .newBuilder()
+                    .setId(e.getId())
+                    .setGroupChatView(view)
+                    .vBuild();
+            builder().addChat(chatPreview);
+        }
     }
 
     @Subscribe

--- a/server/src/main/java/io/spine/examples/chatspn/server/account/UserChatsProjection.java
+++ b/server/src/main/java/io/spine/examples/chatspn/server/account/UserChatsProjection.java
@@ -42,7 +42,7 @@ import io.spine.server.projection.Projection;
 import java.util.Optional;
 
 /**
- * Previews of chats in which the user is a member.
+ * Projection of chats in which the user is a member.
  */
 public final class UserChatsProjection extends Projection<UserId, UserChats, UserChats.Builder> {
 
@@ -53,9 +53,9 @@ public final class UserChatsProjection extends Projection<UserId, UserChats, Use
 
     @Subscribe
     void onUpdate(ChatPreview s) {
-        Optional<Integer> index = findChatIndex(s.getId());
-        if (index.isPresent()) {
-            builder().setChat(index.get(), s);
+        Optional<Integer> chatIndex = findChatIndex(s.getId());
+        if (chatIndex.isPresent()) {
+            builder().setChat(chatIndex.get(), s);
         } else {
             builder().addChat(s);
         }

--- a/server/src/main/java/io/spine/examples/chatspn/server/account/UserChatsProjection.java
+++ b/server/src/main/java/io/spine/examples/chatspn/server/account/UserChatsProjection.java
@@ -32,7 +32,7 @@ import io.spine.examples.chatspn.ChatId;
 import io.spine.examples.chatspn.account.UserChats;
 import io.spine.examples.chatspn.account.event.UserRegistered;
 import io.spine.examples.chatspn.chat.ChatPreview;
-import io.spine.examples.chatspn.chat.ChatPreview.GroupChatView;
+import io.spine.examples.chatspn.chat.GroupChatView;
 import io.spine.examples.chatspn.chat.event.ChatMarkedAsDeleted;
 import io.spine.examples.chatspn.chat.event.MembersAdded;
 import io.spine.examples.chatspn.chat.event.MembersRemoved;
@@ -82,7 +82,7 @@ public final class UserChatsProjection extends Projection<UserId, UserChats, Use
             ChatPreview chatPreview = ChatPreview
                     .newBuilder()
                     .setId(e.getId())
-                    .setGroupChatView(view)
+                    .setGroupChat(view)
                     .vBuild();
             builder().addChat(chatPreview);
         }

--- a/server/src/main/java/io/spine/examples/chatspn/server/account/UserChatsProjection.java
+++ b/server/src/main/java/io/spine/examples/chatspn/server/account/UserChatsProjection.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2023, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.examples.chatspn.server.account;
+
+import io.spine.core.External;
+import io.spine.core.Subscribe;
+import io.spine.core.UserId;
+import io.spine.examples.chatspn.ChatId;
+import io.spine.examples.chatspn.account.UserChats;
+import io.spine.examples.chatspn.account.event.UserRegistered;
+import io.spine.examples.chatspn.chat.ChatPreview;
+import io.spine.server.projection.Projection;
+
+import java.util.Optional;
+
+/**
+ * Previews of chats in which the user is a member.
+ */
+public final class UserChatsProjection extends Projection<UserId, UserChats, UserChats.Builder> {
+
+    @Subscribe
+    void on(UserRegistered e) {
+        builder().setId(e.getUser());
+    }
+
+    @Subscribe
+    void onUpdate(ChatPreview state) {
+    }
+
+    private Optional<Integer> findChatIndex(ChatId chatId) {
+        Optional<ChatPreview> optionalChat =
+                state().getChatList()
+                       .stream()
+                       .filter(chat -> chat.getId()
+                                           .equals(chatId))
+                       .findFirst();
+        if (optionalChat.isPresent()) {
+            int chatIndex = state().getChatList()
+                                   .indexOf(optionalChat.get());
+            return Optional.of(chatIndex);
+        }
+        return Optional.empty();
+    }
+}

--- a/server/src/main/java/io/spine/examples/chatspn/server/account/UserChatsRepository.java
+++ b/server/src/main/java/io/spine/examples/chatspn/server/account/UserChatsRepository.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2023, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.examples.chatspn.server.account;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import io.spine.core.EventContext;
+import io.spine.core.UserId;
+import io.spine.examples.chatspn.ChatId;
+import io.spine.examples.chatspn.account.UserChats;
+import io.spine.examples.chatspn.chat.ChatMembers;
+import io.spine.examples.chatspn.chat.ChatPreview;
+import io.spine.examples.chatspn.server.ProjectionReader;
+import io.spine.server.projection.ProjectionRepository;
+import io.spine.server.route.StateUpdateRouting;
+
+import java.util.List;
+import java.util.Set;
+
+/**
+ * The repository for managing {@link UserChatsProjection} instances.
+ */
+public final class UserChatsRepository
+        extends ProjectionRepository<UserId, UserChatsProjection, UserChats> {
+
+    @Override
+    protected void setupStateRouting(StateUpdateRouting<UserId> routing) {
+        routing.route(ChatPreview.class,
+                      (state, context) -> getChatMembers(state.getId(), context));
+    }
+
+    private Set<UserId> getChatMembers(ChatId chatId, EventContext ctx) {
+        ProjectionReader<ChatId, ChatMembers> reader =
+                new ProjectionReader<>(context().stand(), ChatMembers.class);
+        ImmutableList<ChatMembers> projections =
+                reader.read(ImmutableSet.of(chatId), ctx.getImportContext());
+        if (projections.isEmpty()) {
+            return ImmutableSet.of();
+        }
+        List<UserId> members = projections.get(0)
+                                          .getMemberList();
+        return ImmutableSet.copyOf(members);
+    }
+}

--- a/server/src/main/java/io/spine/examples/chatspn/server/account/UserChatsRepository.java
+++ b/server/src/main/java/io/spine/examples/chatspn/server/account/UserChatsRepository.java
@@ -64,7 +64,7 @@ public final class UserChatsRepository
                .route(MembersAdded.class,
                       (event, context) -> ImmutableSet.copyOf(event.getMemberList()))
                .route(MembersRemoved.class,
-                      (event, context) -> ImmutableSet.copyOf(event.getRemainingMemberList()))
+                      (event, context) -> ImmutableSet.copyOf(event.getRemovedMemberList()))
                .route(ChatMarkedAsDeleted.class,
                       (event, context) -> ImmutableSet.copyOf(event.getMemberList()));
     }

--- a/server/src/main/java/io/spine/examples/chatspn/server/account/UserChatsRepository.java
+++ b/server/src/main/java/io/spine/examples/chatspn/server/account/UserChatsRepository.java
@@ -36,6 +36,7 @@ import io.spine.examples.chatspn.account.event.UserRegistered;
 import io.spine.examples.chatspn.chat.ChatMembers;
 import io.spine.examples.chatspn.chat.ChatPreview;
 import io.spine.examples.chatspn.chat.event.ChatMarkedAsDeleted;
+import io.spine.examples.chatspn.chat.event.MembersAdded;
 import io.spine.examples.chatspn.chat.event.MembersRemoved;
 import io.spine.examples.chatspn.chat.event.UserLeftChat;
 import io.spine.examples.chatspn.server.ChatMembersReader;
@@ -60,6 +61,8 @@ public final class UserChatsRepository
         super.setupEventRouting(routing);
         routing.route(UserRegistered.class, (event, context) -> withId(event.getUser()))
                .route(UserLeftChat.class, (event, context) -> withId(event.getUser()))
+               .route(MembersAdded.class,
+                      (event, context) -> ImmutableSet.copyOf(event.getMemberList()))
                .route(MembersRemoved.class,
                       (event, context) -> ImmutableSet.copyOf(event.getRemainingMemberList()))
                .route(ChatMarkedAsDeleted.class,

--- a/server/src/main/java/io/spine/examples/chatspn/server/chat/ChatAggregate.java
+++ b/server/src/main/java/io/spine/examples/chatspn/server/chat/ChatAggregate.java
@@ -213,6 +213,7 @@ public final class ChatAggregate extends Aggregate<ChatId, Chat, Chat.Builder> {
             return MembersAdded
                     .newBuilder()
                     .setId(c.getId())
+                    .setChatName(state().getName())
                     .setWhoAdded(c.getWhoAdds())
                     .addAllMember(newMembers)
                     .vBuild();

--- a/server/src/main/java/io/spine/examples/chatspn/server/chat/ChatAggregate.java
+++ b/server/src/main/java/io/spine/examples/chatspn/server/chat/ChatAggregate.java
@@ -124,12 +124,14 @@ public final class ChatAggregate extends Aggregate<ChatId, Chat, Chat.Builder> {
     @Assign
     MembersRemoved handle(RemoveMembers c) throws MembersCannotBeRemoved {
         ImmutableList<UserId> remainingMembers = extractRemainingMembers(c);
+        ImmutableList<UserId> membersToRemove = extractMembersToRemove(c);
         if (checkRemovalPossibility(c, remainingMembers)) {
             return MembersRemoved
                     .newBuilder()
                     .setId(c.getId())
                     .setWhoRemoved(c.getWhoRemoves())
                     .addAllRemainingMember(remainingMembers)
+                    .addAllRemovedMember(membersToRemove)
                     .vBuild();
         }
         throw MembersCannotBeRemoved
@@ -168,7 +170,7 @@ public final class ChatAggregate extends Aggregate<ChatId, Chat, Chat.Builder> {
     }
 
     /**
-     * Extracts the list of users who are members of the chat and can be removed.
+     * Extracts the list of users who will remain after members removal.
      */
     private ImmutableList<UserId> extractRemainingMembers(RemoveMembers command) {
         List<UserId> chatMembers = state().getMemberList();
@@ -179,6 +181,20 @@ public final class ChatAggregate extends Aggregate<ChatId, Chat, Chat.Builder> {
                                    userId.equals(command.getWhoRemoves()))
                            .collect(toImmutableList());
         return remainingMembers;
+    }
+
+    /**
+     * Extracts the list of users who are members of the chat and can be removed.
+     */
+    private ImmutableList<UserId> extractMembersToRemove(RemoveMembers command) {
+        List<UserId> chatMembers = state().getMemberList();
+        List<UserId> membersInCommand = command.getMemberList();
+        ImmutableList<UserId> membersToRemove =
+                membersInCommand.stream()
+                        .filter(userId -> chatMembers.contains(userId) &&
+                                !userId.equals(command.getWhoRemoves()))
+                        .collect(toImmutableList());
+        return membersToRemove;
     }
 
     /**

--- a/server/src/main/java/io/spine/examples/chatspn/server/chat/ChatPreviewProjection.java
+++ b/server/src/main/java/io/spine/examples/chatspn/server/chat/ChatPreviewProjection.java
@@ -98,7 +98,7 @@ public final class ChatPreviewProjection
     @Subscribe
     void on(MessageMarkedAsDeleted e) {
         MessagePreview lastMessage = state().getLastMessage();
-        if (!e.getId()
+        if (e.getId()
               .equals(lastMessage.getId())) {
             builder().setLastMessage(MessagePreview.getDefaultInstance());
         }

--- a/server/src/main/java/io/spine/examples/chatspn/server/chat/ChatPreviewProjection.java
+++ b/server/src/main/java/io/spine/examples/chatspn/server/chat/ChatPreviewProjection.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2023, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.examples.chatspn.server.chat;
+
+import io.spine.core.Subscribe;
+import io.spine.examples.chatspn.ChatId;
+import io.spine.examples.chatspn.chat.ChatPreview;
+import io.spine.examples.chatspn.chat.ChatPreview.GroupChatView;
+import io.spine.examples.chatspn.chat.ChatPreview.MessagePreview;
+import io.spine.examples.chatspn.chat.ChatPreview.PersonalChatView;
+import io.spine.examples.chatspn.chat.event.GroupChatCreated;
+import io.spine.examples.chatspn.chat.event.PersonalChatCreated;
+import io.spine.examples.chatspn.message.event.MessageContentUpdated;
+import io.spine.examples.chatspn.message.event.MessageMarkedAsDeleted;
+import io.spine.examples.chatspn.message.event.MessagePosted;
+import io.spine.server.projection.Projection;
+
+/**
+ * Single chat preview.
+ */
+public final class ChatPreviewProjection
+        extends Projection<ChatId, ChatPreview, ChatPreview.Builder> {
+
+    @Subscribe
+    void on(PersonalChatCreated e) {
+        PersonalChatView view = PersonalChatView
+                .newBuilder()
+                .setCreatorId(e.getCreator())
+                //TODO: creator_name
+                .setMemberId(e.getMember())
+                //TODO: member_name
+                .vBuild();
+        builder().setId(e.getId())
+                 .setPersonalChatView(view);
+    }
+
+    @Subscribe
+    void on(GroupChatCreated e) {
+        GroupChatView view = GroupChatView
+                .newBuilder()
+                .setName(e.getName())
+                .vBuild();
+        builder().setId(e.getId())
+                 .setGroupChatView(view);
+    }
+
+    @Subscribe
+    void on(MessagePosted e) {
+        MessagePreview message = MessagePreview
+                .newBuilder()
+                .setId(e.getId())
+                .setUser(e.getUser())
+                .setContent(e.getContent())
+                .setWhenPosted(e.getWhenPosted())
+                .vBuild();
+        builder().setLastMessage(message);
+    }
+
+    @Subscribe
+    void on(MessageContentUpdated e) {
+        MessagePreview lastMessage = state().getLastMessage();
+        if (e.getId()
+             .equals(lastMessage.getId())) {
+            MessagePreview message = MessagePreview
+                    .newBuilder()
+                    .setId(e.getId())
+                    .setUser(e.getUser())
+                    .setContent(e.getContent())
+                    .setWhenPosted(lastMessage.getWhenPosted())
+                    .vBuild();
+            builder().setLastMessage(message);
+        }
+    }
+
+    @Subscribe
+    void on(MessageMarkedAsDeleted e) {
+        MessagePreview lastMessage = state().getLastMessage();
+        if (!e.getId()
+              .equals(lastMessage.getId())) {
+            builder().setLastMessage(MessagePreview.getDefaultInstance());
+        }
+    }
+}

--- a/server/src/main/java/io/spine/examples/chatspn/server/chat/ChatPreviewProjection.java
+++ b/server/src/main/java/io/spine/examples/chatspn/server/chat/ChatPreviewProjection.java
@@ -32,6 +32,7 @@ import io.spine.examples.chatspn.chat.ChatPreview;
 import io.spine.examples.chatspn.chat.ChatPreview.GroupChatView;
 import io.spine.examples.chatspn.chat.ChatPreview.MessagePreview;
 import io.spine.examples.chatspn.chat.ChatPreview.PersonalChatView;
+import io.spine.examples.chatspn.chat.event.ChatMarkedAsDeleted;
 import io.spine.examples.chatspn.chat.event.GroupChatCreated;
 import io.spine.examples.chatspn.chat.event.PersonalChatCreated;
 import io.spine.examples.chatspn.message.event.MessageContentUpdated;
@@ -49,10 +50,8 @@ public final class ChatPreviewProjection
     void on(PersonalChatCreated e) {
         PersonalChatView view = PersonalChatView
                 .newBuilder()
-                .setCreatorId(e.getCreator())
-                //TODO: creator_name
-                .setMemberId(e.getMember())
-                //TODO: member_name
+                .setCreator(e.getCreator())
+                .setMember(e.getMember())
                 .vBuild();
         builder().setId(e.getId())
                  .setPersonalChatView(view);
@@ -103,5 +102,10 @@ public final class ChatPreviewProjection
               .equals(lastMessage.getId())) {
             builder().setLastMessage(MessagePreview.getDefaultInstance());
         }
+    }
+
+    @Subscribe
+    void on(ChatMarkedAsDeleted e) {
+        setDeleted(true);
     }
 }

--- a/server/src/main/java/io/spine/examples/chatspn/server/chat/ChatPreviewProjection.java
+++ b/server/src/main/java/io/spine/examples/chatspn/server/chat/ChatPreviewProjection.java
@@ -29,9 +29,9 @@ package io.spine.examples.chatspn.server.chat;
 import io.spine.core.Subscribe;
 import io.spine.examples.chatspn.ChatId;
 import io.spine.examples.chatspn.chat.ChatPreview;
-import io.spine.examples.chatspn.chat.ChatPreview.GroupChatView;
-import io.spine.examples.chatspn.chat.ChatPreview.MessagePreview;
-import io.spine.examples.chatspn.chat.ChatPreview.PersonalChatView;
+import io.spine.examples.chatspn.chat.GroupChatView;
+import io.spine.examples.chatspn.chat.MessagePreview;
+import io.spine.examples.chatspn.chat.PersonalChatView;
 import io.spine.examples.chatspn.chat.event.ChatMarkedAsDeleted;
 import io.spine.examples.chatspn.chat.event.GroupChatCreated;
 import io.spine.examples.chatspn.chat.event.PersonalChatCreated;
@@ -54,7 +54,7 @@ public final class ChatPreviewProjection
                 .setMember(e.getMember())
                 .vBuild();
         builder().setId(e.getId())
-                 .setPersonalChatView(view);
+                 .setPersonalChat(view);
     }
 
     @Subscribe
@@ -64,7 +64,7 @@ public final class ChatPreviewProjection
                 .setName(e.getName())
                 .vBuild();
         builder().setId(e.getId())
-                 .setGroupChatView(view);
+                 .setGroupChat(view);
     }
 
     @Subscribe

--- a/server/src/main/java/io/spine/examples/chatspn/server/chat/ChatPreviewRepository.java
+++ b/server/src/main/java/io/spine/examples/chatspn/server/chat/ChatPreviewRepository.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2023, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.examples.chatspn.server.chat;
+
+import com.google.errorprone.annotations.OverridingMethodsMustInvokeSuper;
+import io.spine.examples.chatspn.ChatId;
+import io.spine.examples.chatspn.chat.ChatPreview;
+import io.spine.examples.chatspn.chat.event.GroupChatCreated;
+import io.spine.examples.chatspn.chat.event.PersonalChatCreated;
+import io.spine.examples.chatspn.message.event.MessageContentUpdated;
+import io.spine.examples.chatspn.message.event.MessageMarkedAsDeleted;
+import io.spine.examples.chatspn.message.event.MessagePosted;
+import io.spine.server.projection.ProjectionRepository;
+import io.spine.server.route.EventRouting;
+
+import static io.spine.server.route.EventRoute.withId;
+
+/**
+ * The repository for managing {@link ChatMembersProjection} instances.
+ */
+public final class ChatPreviewRepository
+        extends ProjectionRepository<ChatId, ChatPreviewProjection, ChatPreview> {
+
+    @OverridingMethodsMustInvokeSuper
+    @Override
+    protected void setupEventRouting(EventRouting<ChatId> routing) {
+        super.setupEventRouting(routing);
+        routing.route(PersonalChatCreated.class, (event, context) -> withId(event.getId()))
+               .route(GroupChatCreated.class, (event, context) -> withId(event.getId()))
+               .route(MessagePosted.class, (event, context) -> withId(event.getChat()))
+               .route(MessageContentUpdated.class, (event, context) -> withId(event.getChat()))
+               .route(MessageMarkedAsDeleted.class, (event, context) -> withId(event.getChat()));
+    }
+}

--- a/server/src/main/java/io/spine/examples/chatspn/server/chat/ChatPreviewRepository.java
+++ b/server/src/main/java/io/spine/examples/chatspn/server/chat/ChatPreviewRepository.java
@@ -40,7 +40,7 @@ import io.spine.server.route.EventRouting;
 import static io.spine.server.route.EventRoute.withId;
 
 /**
- * The repository for managing {@link ChatMembersProjection} instances.
+ * The repository for managing {@link ChatPreviewProjection} instances.
  */
 public final class ChatPreviewRepository
         extends ProjectionRepository<ChatId, ChatPreviewProjection, ChatPreview> {

--- a/server/src/main/java/io/spine/examples/chatspn/server/message/MessageEditingProcess.java
+++ b/server/src/main/java/io/spine/examples/chatspn/server/message/MessageEditingProcess.java
@@ -38,6 +38,7 @@ import io.spine.examples.chatspn.message.event.MessageEdited;
 import io.spine.examples.chatspn.message.event.MessageEditingFailed;
 import io.spine.examples.chatspn.message.rejection.EditingRejections.MessageContentCannotBeUpdated;
 import io.spine.examples.chatspn.message.rejection.MessageCannotBeEdited;
+import io.spine.examples.chatspn.server.ChatMembersReader;
 import io.spine.examples.chatspn.server.ProjectionReader;
 import io.spine.server.command.Command;
 import io.spine.server.event.React;

--- a/server/src/main/java/io/spine/examples/chatspn/server/message/MessageRemovalProcess.java
+++ b/server/src/main/java/io/spine/examples/chatspn/server/message/MessageRemovalProcess.java
@@ -38,6 +38,7 @@ import io.spine.examples.chatspn.message.event.MessageRemovalFailed;
 import io.spine.examples.chatspn.message.event.MessageRemoved;
 import io.spine.examples.chatspn.message.rejection.MessageCannotBeRemoved;
 import io.spine.examples.chatspn.message.rejection.RemovalRejections.MessageCannotBeMarkedAsDeleted;
+import io.spine.examples.chatspn.server.ChatMembersReader;
 import io.spine.examples.chatspn.server.ProjectionReader;
 import io.spine.server.command.Command;
 import io.spine.server.event.React;

--- a/server/src/main/java/io/spine/examples/chatspn/server/message/MessageSendingProcess.java
+++ b/server/src/main/java/io/spine/examples/chatspn/server/message/MessageSendingProcess.java
@@ -36,6 +36,7 @@ import io.spine.examples.chatspn.message.command.SendMessage;
 import io.spine.examples.chatspn.message.event.MessagePosted;
 import io.spine.examples.chatspn.message.event.MessageSent;
 import io.spine.examples.chatspn.message.rejection.MessageCannotBeSent;
+import io.spine.examples.chatspn.server.ChatMembersReader;
 import io.spine.examples.chatspn.server.ProjectionReader;
 import io.spine.server.command.Command;
 import io.spine.server.event.React;

--- a/server/src/main/java/io/spine/examples/chatspn/server/package-info.java
+++ b/server/src/main/java/io/spine/examples/chatspn/server/package-info.java
@@ -27,12 +27,13 @@
 /**
  * Provides server-side code of the ChatSPN application.
  */
-@BoundedContext(ChatsContext.NAME)
+@BoundedContext(BoundedContextName.CHATS)
 @CheckReturnValue
 @ParametersAreNonnullByDefault
 package io.spine.examples.chatspn.server;
 
 import com.google.errorprone.annotations.CheckReturnValue;
 import io.spine.core.BoundedContext;
+import io.spine.examples.chatspn.BoundedContextName;
 
 import javax.annotation.ParametersAreNonnullByDefault;

--- a/server/src/main/java/io/spine/examples/chatspn/server/package-info.java
+++ b/server/src/main/java/io/spine/examples/chatspn/server/package-info.java
@@ -27,13 +27,14 @@
 /**
  * Provides server-side code of the ChatSPN application.
  */
-@BoundedContext(BoundedContextName.CHATS)
+@BoundedContext(CHATS)
 @CheckReturnValue
 @ParametersAreNonnullByDefault
 package io.spine.examples.chatspn.server;
 
 import com.google.errorprone.annotations.CheckReturnValue;
 import io.spine.core.BoundedContext;
-import io.spine.examples.chatspn.BoundedContextName;
 
 import javax.annotation.ParametersAreNonnullByDefault;
+
+import static io.spine.examples.chatspn.BoundedContextName.CHATS;

--- a/server/src/main/java/io/spine/examples/chatspn/server/package-info.java
+++ b/server/src/main/java/io/spine/examples/chatspn/server/package-info.java
@@ -37,4 +37,4 @@ import io.spine.core.BoundedContext;
 
 import javax.annotation.ParametersAreNonnullByDefault;
 
-import static io.spine.examples.chatspn.BoundedContextName.CHATS;
+import static io.spine.examples.chatspn.BoundedContextNames.CHATS;

--- a/server/src/test/java/io/spine/examples/chatspn/server/chat/ChatTest.java
+++ b/server/src/test/java/io/spine/examples/chatspn/server/chat/ChatTest.java
@@ -103,7 +103,7 @@ final class ChatTest extends ContextAwareTest {
     }
 
     @Test
-    @DisplayName("create a `ChatPreview` projection and update the `UserChats` projection" +
+    @DisplayName("create a `ChatPreview` projection and update the `UserChats` projection " +
             "after personal chat creation")
     void updateProjectionsAfterPersonalChatCreation() {
         CreatePersonalChat command = createPersonalChatCommand();
@@ -131,7 +131,7 @@ final class ChatTest extends ContextAwareTest {
     }
 
     @Test
-    @DisplayName("create a `ChatPreview` projection and update the `UserChats` projection" +
+    @DisplayName("create a `ChatPreview` projection and update the `UserChats` projection " +
             "after group chat creation")
     void updateProjectionsAfterGroupChatCreation() {
         CreateGroupChat command = createGroupChatCommand();

--- a/server/src/test/java/io/spine/examples/chatspn/server/chat/ChatTest.java
+++ b/server/src/test/java/io/spine/examples/chatspn/server/chat/ChatTest.java
@@ -262,7 +262,7 @@ final class ChatTest extends ContextAwareTest {
             context().receivesCommand(command);
             ImmutableList<UserId> addedMembers =
                     ImmutableList.of(membersToAdd.get(0));
-            MembersAdded expected = membersAdded(command, chat, addedMembers);
+            MembersAdded expected = membersAdded(command, chat.getName(), addedMembers);
 
             context().assertEvent(expected);
         }

--- a/server/src/test/java/io/spine/examples/chatspn/server/chat/ChatTest.java
+++ b/server/src/test/java/io/spine/examples/chatspn/server/chat/ChatTest.java
@@ -214,7 +214,7 @@ final class ChatTest extends ContextAwareTest {
             context().receivesCommand(command);
             ImmutableList<UserId> addedMembers =
                     ImmutableList.of(membersToAdd.get(0));
-            MembersAdded expected = membersAddedFrom(command, addedMembers);
+            MembersAdded expected = membersAdded(command, chat, addedMembers);
 
             context().assertEvent(expected);
         }

--- a/server/src/test/java/io/spine/examples/chatspn/server/chat/ChatTest.java
+++ b/server/src/test/java/io/spine/examples/chatspn/server/chat/ChatTest.java
@@ -36,9 +36,9 @@ import io.spine.examples.chatspn.chat.command.LeaveChat;
 import io.spine.examples.chatspn.chat.command.RemoveMembers;
 import io.spine.examples.chatspn.chat.event.ChatDeleted;
 import io.spine.examples.chatspn.chat.event.GroupChatCreated;
+import io.spine.examples.chatspn.chat.event.LastMemberLeftChat;
 import io.spine.examples.chatspn.chat.event.MembersAdded;
 import io.spine.examples.chatspn.chat.event.MembersRemoved;
-import io.spine.examples.chatspn.chat.event.LastMemberLeftChat;
 import io.spine.examples.chatspn.chat.event.PersonalChatCreated;
 import io.spine.examples.chatspn.chat.event.UserLeftChat;
 import io.spine.examples.chatspn.chat.rejection.Rejections.MembersCannotBeAdded;
@@ -64,12 +64,12 @@ import static io.spine.examples.chatspn.server.chat.given.ChatTestEnv.createGrou
 import static io.spine.examples.chatspn.server.chat.given.ChatTestEnv.createPersonalChatCommand;
 import static io.spine.examples.chatspn.server.chat.given.ChatTestEnv.createPersonalChatIn;
 import static io.spine.examples.chatspn.server.chat.given.ChatTestEnv.groupChatCreatedFrom;
+import static io.spine.examples.chatspn.server.chat.given.ChatTestEnv.lastMemberLeftChat;
 import static io.spine.examples.chatspn.server.chat.given.ChatTestEnv.leaveChat;
 import static io.spine.examples.chatspn.server.chat.given.ChatTestEnv.membersAddedFrom;
 import static io.spine.examples.chatspn.server.chat.given.ChatTestEnv.membersCannotBeAddedFrom;
 import static io.spine.examples.chatspn.server.chat.given.ChatTestEnv.membersCannotBeRemovedFrom;
-import static io.spine.examples.chatspn.server.chat.given.ChatTestEnv.membersRemovedFrom;
-import static io.spine.examples.chatspn.server.chat.given.ChatTestEnv.lastMemberLeftChat;
+import static io.spine.examples.chatspn.server.chat.given.ChatTestEnv.membersRemoved;
 import static io.spine.examples.chatspn.server.chat.given.ChatTestEnv.personalChatCreatedFrom;
 import static io.spine.examples.chatspn.server.chat.given.ChatTestEnv.removeMembersCommandWith;
 import static io.spine.examples.chatspn.server.chat.given.ChatTestEnv.userCannotLeaveChat;
@@ -125,7 +125,8 @@ final class ChatTest extends ContextAwareTest {
             RemoveMembers command = removeMembersCommandWith(chat, membersToRemove);
             context().receivesCommand(command);
             ImmutableList<UserId> remainingMembers = ImmutableList.of(chatOwner);
-            MembersRemoved expected = membersRemovedFrom(command, remainingMembers);
+            ImmutableList<UserId> removedMembers = ImmutableList.of(commonChatMember);
+            MembersRemoved expected = membersRemoved(command, remainingMembers, removedMembers);
 
             context().assertEvent(expected);
         }

--- a/server/src/test/java/io/spine/examples/chatspn/server/chat/given/ChatTestEnv.java
+++ b/server/src/test/java/io/spine/examples/chatspn/server/chat/given/ChatTestEnv.java
@@ -30,7 +30,11 @@ import com.google.common.collect.ImmutableList;
 import io.spine.core.UserId;
 import io.spine.examples.chatspn.ChatDeletionId;
 import io.spine.examples.chatspn.ChatId;
+import io.spine.examples.chatspn.account.UserChats;
 import io.spine.examples.chatspn.chat.Chat;
+import io.spine.examples.chatspn.chat.ChatPreview;
+import io.spine.examples.chatspn.chat.ChatPreview.GroupChatView;
+import io.spine.examples.chatspn.chat.ChatPreview.PersonalChatView;
 import io.spine.examples.chatspn.chat.command.AddMembers;
 import io.spine.examples.chatspn.chat.command.CreateGroupChat;
 import io.spine.examples.chatspn.chat.command.CreatePersonalChat;
@@ -366,6 +370,72 @@ public final class ChatTestEnv {
                 .toBuilder()
                 .clearMember()
                 .addAllMember(newMemberList)
+                .vBuild();
+        return state;
+    }
+
+    public static ChatPreview personalChatPreview(CreatePersonalChat c) {
+        PersonalChatView view = PersonalChatView
+                .newBuilder()
+                .setCreator(c.getCreator())
+                .setMember(c.getMember())
+                .vBuild();
+        ChatPreview state = ChatPreview
+                .newBuilder()
+                .setId(c.getId())
+                .setPersonalChatView(view)
+                .vBuild();
+        return state;
+    }
+
+    public static ChatPreview groupChatPreview(CreateGroupChat c) {
+        ChatPreview state = ChatPreview
+                .newBuilder()
+                .setId(c.getId())
+                .setGroupChatView(groupChatView(c.getName()))
+                .vBuild();
+        return state;
+    }
+
+    public static ChatPreview groupChatPreview(Chat chat) {
+        ChatPreview state = ChatPreview
+                .newBuilder()
+                .setId(chat.getId())
+                .setGroupChatView(groupChatView(chat.getName()))
+                .vBuild();
+        return state;
+    }
+
+    public static GroupChatView groupChatView(String name) {
+        GroupChatView view = GroupChatView
+                .newBuilder()
+                .setName(name)
+                .vBuild();
+        return view;
+    }
+
+    public static UserChats userChats(ChatPreview chatPreview, UserId user) {
+        UserChats state = UserChats
+                .newBuilder()
+                .setId(user)
+                .addChat(chatPreview)
+                .vBuild();
+        return state;
+    }
+
+    public static UserChats userChats(Chat groupChat, UserId user) {
+        UserChats state = UserChats
+                .newBuilder()
+                .setId(user)
+                .addChat(groupChatPreview(groupChat))
+                .vBuild();
+        return state;
+    }
+
+    public static UserChats emptyUserChats(UserId user) {
+        UserChats state = UserChats
+                .newBuilder()
+                .setId(user)
                 .vBuild();
         return state;
     }

--- a/server/src/test/java/io/spine/examples/chatspn/server/chat/given/ChatTestEnv.java
+++ b/server/src/test/java/io/spine/examples/chatspn/server/chat/given/ChatTestEnv.java
@@ -216,11 +216,13 @@ public final class ChatTestEnv {
         return command;
     }
 
-    public static MembersAdded membersAddedFrom(AddMembers c,
-                                                List<UserId> addedMembers) {
+    public static MembersAdded membersAdded(AddMembers c,
+                                            Chat chat,
+                                            List<UserId> addedMembers) {
         MembersAdded event = MembersAdded
                 .newBuilder()
                 .setId(c.getId())
+                .setChatName(chat.getName())
                 .setWhoAdded(c.getWhoAdds())
                 .addAllMember(addedMembers)
                 .vBuild();

--- a/server/src/test/java/io/spine/examples/chatspn/server/chat/given/ChatTestEnv.java
+++ b/server/src/test/java/io/spine/examples/chatspn/server/chat/given/ChatTestEnv.java
@@ -33,8 +33,8 @@ import io.spine.examples.chatspn.ChatId;
 import io.spine.examples.chatspn.account.UserChats;
 import io.spine.examples.chatspn.chat.Chat;
 import io.spine.examples.chatspn.chat.ChatPreview;
-import io.spine.examples.chatspn.chat.ChatPreview.GroupChatView;
-import io.spine.examples.chatspn.chat.ChatPreview.PersonalChatView;
+import io.spine.examples.chatspn.chat.GroupChatView;
+import io.spine.examples.chatspn.chat.PersonalChatView;
 import io.spine.examples.chatspn.chat.command.AddMembers;
 import io.spine.examples.chatspn.chat.command.CreateGroupChat;
 import io.spine.examples.chatspn.chat.command.CreatePersonalChat;
@@ -383,7 +383,7 @@ public final class ChatTestEnv {
         ChatPreview state = ChatPreview
                 .newBuilder()
                 .setId(c.getId())
-                .setPersonalChatView(view)
+                .setPersonalChat(view)
                 .vBuild();
         return state;
     }
@@ -392,7 +392,7 @@ public final class ChatTestEnv {
         ChatPreview state = ChatPreview
                 .newBuilder()
                 .setId(c.getId())
-                .setGroupChatView(groupChatView(c.getName()))
+                .setGroupChat(groupChatView(c.getName()))
                 .vBuild();
         return state;
     }
@@ -401,7 +401,7 @@ public final class ChatTestEnv {
         ChatPreview state = ChatPreview
                 .newBuilder()
                 .setId(chat.getId())
-                .setGroupChatView(groupChatView(chat.getName()))
+                .setGroupChat(groupChatView(chat.getName()))
                 .vBuild();
         return state;
     }

--- a/server/src/test/java/io/spine/examples/chatspn/server/chat/given/ChatTestEnv.java
+++ b/server/src/test/java/io/spine/examples/chatspn/server/chat/given/ChatTestEnv.java
@@ -38,8 +38,8 @@ import io.spine.examples.chatspn.chat.command.DeleteChat;
 import io.spine.examples.chatspn.chat.command.LeaveChat;
 import io.spine.examples.chatspn.chat.command.RemoveMembers;
 import io.spine.examples.chatspn.chat.event.ChatDeleted;
-import io.spine.examples.chatspn.chat.event.LastMemberLeftChat;
 import io.spine.examples.chatspn.chat.event.GroupChatCreated;
+import io.spine.examples.chatspn.chat.event.LastMemberLeftChat;
 import io.spine.examples.chatspn.chat.event.MembersAdded;
 import io.spine.examples.chatspn.chat.event.MembersRemoved;
 import io.spine.examples.chatspn.chat.event.PersonalChatCreated;
@@ -270,13 +270,15 @@ public final class ChatTestEnv {
         return command;
     }
 
-    public static MembersRemoved membersRemovedFrom(RemoveMembers command,
-                                                    List<UserId> remainingMembers) {
+    public static MembersRemoved membersRemoved(RemoveMembers command,
+                                                List<UserId> remainingMembers,
+                                                List<UserId> removedMembers) {
         MembersRemoved event = MembersRemoved
                 .newBuilder()
                 .setId(command.getId())
                 .setWhoRemoved(command.getWhoRemoves())
                 .addAllRemainingMember(remainingMembers)
+                .addAllRemovedMember(removedMembers)
                 .vBuild();
         return event;
     }

--- a/server/src/test/java/io/spine/examples/chatspn/server/chat/given/ChatTestEnv.java
+++ b/server/src/test/java/io/spine/examples/chatspn/server/chat/given/ChatTestEnv.java
@@ -221,12 +221,12 @@ public final class ChatTestEnv {
     }
 
     public static MembersAdded membersAdded(AddMembers c,
-                                            Chat chat,
+                                            String chatName,
                                             List<UserId> addedMembers) {
         MembersAdded event = MembersAdded
                 .newBuilder()
                 .setId(c.getId())
-                .setChatName(chat.getName())
+                .setChatName(chatName)
                 .setWhoAdded(c.getWhoAdds())
                 .addAllMember(addedMembers)
                 .vBuild();

--- a/server/src/test/java/io/spine/examples/chatspn/server/message/MessageSendingTest.java
+++ b/server/src/test/java/io/spine/examples/chatspn/server/message/MessageSendingTest.java
@@ -26,7 +26,9 @@
 
 package io.spine.examples.chatspn.server.message;
 
+import io.spine.examples.chatspn.account.UserChats;
 import io.spine.examples.chatspn.chat.Chat;
+import io.spine.examples.chatspn.chat.ChatPreview;
 import io.spine.examples.chatspn.message.Message;
 import io.spine.examples.chatspn.message.MessageView;
 import io.spine.examples.chatspn.message.command.SendMessage;
@@ -42,6 +44,8 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import static io.spine.examples.chatspn.server.chat.given.ChatTestEnv.createDeletedGroupChatIn;
+import static io.spine.examples.chatspn.server.chat.given.ChatTestEnv.userChats;
+import static io.spine.examples.chatspn.server.message.given.MessageSendingTestEnv.chatPreview;
 import static io.spine.examples.chatspn.server.message.given.MessageSendingTestEnv.messageCannotBeSentFrom;
 import static io.spine.examples.chatspn.server.message.given.MessageSendingTestEnv.messageFrom;
 import static io.spine.examples.chatspn.server.message.given.MessageSendingTestEnv.messagePostedFrom;
@@ -107,6 +111,19 @@ public final class MessageSendingTest extends ContextAwareTest {
         context().assertState(expected.getId(), MessageView.class)
                  .comparingExpectedFieldsOnly()
                  .isEqualTo(expected);
+    }
+
+    @Test
+    @DisplayName("update last message in `ChatPreview` and `UserChats` projections")
+    void updateLastMessage() {
+        Chat chat = createRandomChatIn(context());
+        SendMessage command = randomSendMessageCommand(chat);
+        context().receivesCommand(command);
+        ChatPreview chatPreview = chatPreview(chat, command);
+        UserChats userChats = userChats(chatPreview, chat.getMember(0));
+
+        context().assertState(chatPreview.getId(), chatPreview);
+        context().assertState(userChats.getId(), userChats);
     }
 
     @Nested

--- a/server/src/test/java/io/spine/examples/chatspn/server/message/given/MessageEditingTestEnv.java
+++ b/server/src/test/java/io/spine/examples/chatspn/server/message/given/MessageEditingTestEnv.java
@@ -30,6 +30,7 @@ import io.spine.core.UserId;
 import io.spine.examples.chatspn.MessageId;
 import io.spine.examples.chatspn.chat.Chat;
 import io.spine.examples.chatspn.chat.ChatPreview;
+import io.spine.examples.chatspn.chat.MessagePreview;
 import io.spine.examples.chatspn.message.Message;
 import io.spine.examples.chatspn.message.MessageView;
 import io.spine.examples.chatspn.message.command.EditMessage;
@@ -161,7 +162,7 @@ public final class MessageEditingTestEnv {
     }
 
     public static ChatPreview chatPreview(Chat chat, EditMessage command) {
-        ChatPreview.MessagePreview messageView = ChatPreview.MessagePreview
+        MessagePreview messageView = MessagePreview
                 .newBuilder()
                 .setId(command.getId())
                 .setUser(command.getUser())
@@ -170,7 +171,7 @@ public final class MessageEditingTestEnv {
         ChatPreview state = ChatPreview
                 .newBuilder()
                 .setId(chat.getId())
-                .setGroupChatView(groupChatView(chat.getName()))
+                .setGroupChat(groupChatView(chat.getName()))
                 .setLastMessage(messageView)
                 .vBuild();
         return state;

--- a/server/src/test/java/io/spine/examples/chatspn/server/message/given/MessageEditingTestEnv.java
+++ b/server/src/test/java/io/spine/examples/chatspn/server/message/given/MessageEditingTestEnv.java
@@ -28,6 +28,8 @@ package io.spine.examples.chatspn.server.message.given;
 
 import io.spine.core.UserId;
 import io.spine.examples.chatspn.MessageId;
+import io.spine.examples.chatspn.chat.Chat;
+import io.spine.examples.chatspn.chat.ChatPreview;
 import io.spine.examples.chatspn.message.Message;
 import io.spine.examples.chatspn.message.MessageView;
 import io.spine.examples.chatspn.message.command.EditMessage;
@@ -37,6 +39,7 @@ import io.spine.examples.chatspn.message.event.MessageEditingFailed;
 import io.spine.examples.chatspn.message.rejection.EditingRejections.MessageCannotBeEdited;
 import io.spine.examples.chatspn.message.rejection.EditingRejections.MessageContentCannotBeUpdated;
 
+import static io.spine.examples.chatspn.server.chat.given.ChatTestEnv.groupChatView;
 import static io.spine.testing.TestValues.randomString;
 
 public final class MessageEditingTestEnv {
@@ -155,5 +158,21 @@ public final class MessageEditingTestEnv {
                 .setSuggestedContent(c.getSuggestedContent())
                 .vBuild();
         return rejection;
+    }
+
+    public static ChatPreview chatPreview(Chat chat, EditMessage command) {
+        ChatPreview.MessagePreview messageView = ChatPreview.MessagePreview
+                .newBuilder()
+                .setId(command.getId())
+                .setUser(command.getUser())
+                .setContent(command.getSuggestedContent())
+                .buildPartial();
+        ChatPreview state = ChatPreview
+                .newBuilder()
+                .setId(chat.getId())
+                .setGroupChatView(groupChatView(chat.getName()))
+                .setLastMessage(messageView)
+                .vBuild();
+        return state;
     }
 }

--- a/server/src/test/java/io/spine/examples/chatspn/server/message/given/MessageRemovalTestEnv.java
+++ b/server/src/test/java/io/spine/examples/chatspn/server/message/given/MessageRemovalTestEnv.java
@@ -31,7 +31,7 @@ import io.spine.examples.chatspn.MessageId;
 import io.spine.examples.chatspn.MessageRemovalId;
 import io.spine.examples.chatspn.chat.Chat;
 import io.spine.examples.chatspn.chat.ChatPreview;
-import io.spine.examples.chatspn.chat.ChatPreview.MessagePreview;
+import io.spine.examples.chatspn.chat.MessagePreview;
 import io.spine.examples.chatspn.message.Message;
 import io.spine.examples.chatspn.message.command.RemoveMessage;
 import io.spine.examples.chatspn.message.event.MessageMarkedAsDeleted;
@@ -154,8 +154,8 @@ public final class MessageRemovalTestEnv {
         ChatPreview state = ChatPreview
                 .newBuilder()
                 .setId(chat.getId())
-                .setGroupChatView(groupChatView(chat.getName()))
-                .setLastMessage(ChatPreview.MessagePreview.getDefaultInstance())
+                .setGroupChat(groupChatView(chat.getName()))
+                .setLastMessage(MessagePreview.getDefaultInstance())
                 .vBuild();
         return state;
     }
@@ -170,7 +170,7 @@ public final class MessageRemovalTestEnv {
         ChatPreview state = ChatPreview
                 .newBuilder()
                 .setId(chat.getId())
-                .setGroupChatView(groupChatView(chat.getName()))
+                .setGroupChat(groupChatView(chat.getName()))
                 .setLastMessage(messageView)
                 .vBuild();
         return state;

--- a/server/src/test/java/io/spine/examples/chatspn/server/message/given/MessageRemovalTestEnv.java
+++ b/server/src/test/java/io/spine/examples/chatspn/server/message/given/MessageRemovalTestEnv.java
@@ -29,6 +29,9 @@ package io.spine.examples.chatspn.server.message.given;
 import io.spine.core.UserId;
 import io.spine.examples.chatspn.MessageId;
 import io.spine.examples.chatspn.MessageRemovalId;
+import io.spine.examples.chatspn.chat.Chat;
+import io.spine.examples.chatspn.chat.ChatPreview;
+import io.spine.examples.chatspn.chat.ChatPreview.MessagePreview;
 import io.spine.examples.chatspn.message.Message;
 import io.spine.examples.chatspn.message.command.RemoveMessage;
 import io.spine.examples.chatspn.message.event.MessageMarkedAsDeleted;
@@ -36,6 +39,8 @@ import io.spine.examples.chatspn.message.event.MessageRemovalFailed;
 import io.spine.examples.chatspn.message.event.MessageRemoved;
 import io.spine.examples.chatspn.message.rejection.RemovalRejections.MessageCannotBeMarkedAsDeleted;
 import io.spine.examples.chatspn.message.rejection.RemovalRejections.MessageCannotBeRemoved;
+
+import static io.spine.examples.chatspn.server.chat.given.ChatTestEnv.groupChatView;
 
 public final class MessageRemovalTestEnv {
 
@@ -143,5 +148,31 @@ public final class MessageRemovalTestEnv {
                 .newBuilder()
                 .setId(id)
                 .vBuild();
+    }
+
+    public static ChatPreview chatPreview(Chat chat) {
+        ChatPreview state = ChatPreview
+                .newBuilder()
+                .setId(chat.getId())
+                .setGroupChatView(groupChatView(chat.getName()))
+                .setLastMessage(ChatPreview.MessagePreview.getDefaultInstance())
+                .vBuild();
+        return state;
+    }
+
+    public static ChatPreview chatPreviewWithMessage(Chat chat, Message message) {
+        MessagePreview messageView = MessagePreview
+                .newBuilder()
+                .setId(message.getId())
+                .setUser(message.getUser())
+                .setContent(message.getContent())
+                .buildPartial();
+        ChatPreview state = ChatPreview
+                .newBuilder()
+                .setId(chat.getId())
+                .setGroupChatView(groupChatView(chat.getName()))
+                .setLastMessage(messageView)
+                .vBuild();
+        return state;
     }
 }

--- a/server/src/test/java/io/spine/examples/chatspn/server/message/given/MessageSendingTestEnv.java
+++ b/server/src/test/java/io/spine/examples/chatspn/server/message/given/MessageSendingTestEnv.java
@@ -29,6 +29,8 @@ package io.spine.examples.chatspn.server.message.given;
 import io.spine.core.UserId;
 import io.spine.examples.chatspn.MessageId;
 import io.spine.examples.chatspn.chat.Chat;
+import io.spine.examples.chatspn.chat.ChatPreview;
+import io.spine.examples.chatspn.chat.ChatPreview.MessagePreview;
 import io.spine.examples.chatspn.message.Message;
 import io.spine.examples.chatspn.message.MessageView;
 import io.spine.examples.chatspn.message.command.SendMessage;
@@ -36,6 +38,7 @@ import io.spine.examples.chatspn.message.event.MessagePosted;
 import io.spine.examples.chatspn.message.event.MessageSent;
 import io.spine.examples.chatspn.message.rejection.SendingRejections.MessageCannotBeSent;
 
+import static io.spine.examples.chatspn.server.chat.given.ChatTestEnv.groupChatView;
 import static io.spine.testing.TestValues.randomString;
 
 public final class MessageSendingTestEnv {
@@ -121,5 +124,21 @@ public final class MessageSendingTestEnv {
                 .setContent(c.getContent())
                 .vBuild();
         return rejection;
+    }
+
+    public static ChatPreview chatPreview(Chat chat, SendMessage command) {
+        MessagePreview messagePreview = MessagePreview
+                .newBuilder()
+                .setId(command.getId())
+                .setUser(command.getUser())
+                .setContent(command.getContent())
+                .buildPartial();
+        ChatPreview state = ChatPreview
+                .newBuilder()
+                .setId(chat.getId())
+                .setGroupChatView(groupChatView(chat.getName()))
+                .setLastMessage(messagePreview)
+                .vBuild();
+        return state;
     }
 }

--- a/server/src/test/java/io/spine/examples/chatspn/server/message/given/MessageSendingTestEnv.java
+++ b/server/src/test/java/io/spine/examples/chatspn/server/message/given/MessageSendingTestEnv.java
@@ -30,7 +30,7 @@ import io.spine.core.UserId;
 import io.spine.examples.chatspn.MessageId;
 import io.spine.examples.chatspn.chat.Chat;
 import io.spine.examples.chatspn.chat.ChatPreview;
-import io.spine.examples.chatspn.chat.ChatPreview.MessagePreview;
+import io.spine.examples.chatspn.chat.MessagePreview;
 import io.spine.examples.chatspn.message.Message;
 import io.spine.examples.chatspn.message.MessageView;
 import io.spine.examples.chatspn.message.command.SendMessage;
@@ -136,7 +136,7 @@ public final class MessageSendingTestEnv {
         ChatPreview state = ChatPreview
                 .newBuilder()
                 .setId(chat.getId())
-                .setGroupChatView(groupChatView(chat.getName()))
+                .setGroupChat(groupChatView(chat.getName()))
                 .setLastMessage(messagePreview)
                 .vBuild();
         return state;


### PR DESCRIPTION
This PR adds an implementation of the `UserChats` and `ChatPreview` projections.

The `ChatPreview` projection shows the single chat's information before you click on it to read the message history.
Contains info about the chat view(name in the group chat and members IDs in personal) and the last message.

The `UserChats` projection contains all chats in which the user is a member with their previews.

The `removed_user` field was added to `MembersRemoved` and `chat_name` to `MembersAdded`.